### PR TITLE
Remove redundant get_devices() call from config flow

### DIFF
--- a/custom_components/cool_open_integration/config_flow.py
+++ b/custom_components/cool_open_integration/config_flow.py
@@ -42,38 +42,19 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
     Data has the keys from STEP_USER_DATA_SCHEMA with values provided by the user.
     """
 
-    # If your PyPI package is not built with async, pass your methods
-    # to the executor:
-    # await hass.async_add_executor_job(
-    #     your_validate_func, data["username"], data["password"]
-    # )
-
     token = await CoolAutomationClient.authenticate(data["username"], data["password"])
 
     if token == "Unauthorized":
         raise InvalidAuth
 
     api: CoolAutomationClient = await CoolAutomationClient.create(token, logger=_LOGGER)
-    devices = await api.get_devices()
     me = await api.get_me()
-    id = me.id
 
-    if not devices:
-        raise Exception("No devices available")
-
-    # If you cannot connect:
-    # throw CannotConnect
-    # If the authentication is wrong:
-    # InvalidAuth
-
-    # Return info that you want to store in the config entry.
-    devices = [device.serial for device in devices]
     return {
         "username": data["username"],
         "password": data["password"],
         "token": token,
-        "devices": devices,
-        "id": id,
+        "id": me.id,
     }
 
 


### PR DESCRIPTION
Title: Remove redundant get_devices() call from config flow

## Problem

`validate_input()` in `config_flow.py` was calling `api.get_devices()` and storing the device serial list in the config entry. No runtime module ever reads that stored list back — it was dead data from an earlier design.

More critically, this call was actively crashing during setup. The `DeviceResponseData.units` field uses Pydantic strict string validation, which rejects the nested lists (representing physical communication lines) that the CoolAutomation API actually returns. This raised a `ValidationError` before `validate_input()` could return, preventing new users from completing setup entirely.

## Fix

Remove the `get_devices()` call and the `devices` key from the returned config entry data. The "no devices available" guard it provided is already covered by the unit discovery step in `async_setup_entry`, which is the correct place for that check.

## Changes

- `config_flow.py`: remove `get_devices()` call, remove dead comments, simplify returned dict to `username`, `password`, `token`, `id`

## Test

Configure the integration from scratch — the config flow should complete without error on Python 3.12+ (including 3.14).