### PR TITLE
Bulk polling + HA-friendly SSL context (0.0.16)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,4 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+.venv-test/

--- a/custom_components/cool_open_integration/__init__.py
+++ b/custom_components/cool_open_integration/__init__.py
@@ -5,6 +5,7 @@ import logging
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
+from homeassistant.util.ssl import client_context
 
 from cool_open_client.hvac_units_factory import HVACUnitsFactory
 from cool_open_client.cool_automation_client import (
@@ -33,9 +34,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     #     return bool(hass.config_entries.async_entries(DOMAIN))
 
     _LOGGER.debug("async setup")
+    # Build the SSL context off the event loop once, then thread it through
+    # every cool-open-client call site so the library never blocks the loop
+    # reading the system CA bundle.
+    ssl_ctx = await hass.async_add_executor_job(client_context)
     token = entry.data["token"]
     try:
-        client = await CoolAutomationClient.create(token=token)
+        client = await CoolAutomationClient.create(token=token, ssl_context=ssl_ctx)
     except OSError as error:
         raise ConfigEntryNotReady() from error
     except InvalidTokenException as error:
@@ -43,11 +48,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         username = entry.data["username"]
         password = entry.data["password"]
         try:
-            token = await CoolAutomationClient.authenticate(username, password)
+            token = await CoolAutomationClient.authenticate(
+                username, password, ssl_context=ssl_ctx
+            )
             hass.config_entries.async_update_entry(
                 entry, data={"username": username, "password": password, "token": token}
             )
-            client = await CoolAutomationClient.create(token=token)
+            client = await CoolAutomationClient.create(token=token, ssl_context=ssl_ctx)
         except Exception as error:
             _LOGGER.error("Can't authenticate, wrong credentials: %s", error)
             raise ConfigEntryAuthFailed(
@@ -57,7 +64,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         _LOGGER.error("General Error: %s", error)
         raise ConfigEntryNotReady() from error
     try:
-        units_factory = await HVACUnitsFactory.create(token=token)
+        units_factory = await HVACUnitsFactory.create(token=token, ssl_context=ssl_ctx)
         units = await units_factory.generate_units_from_api()
         if not units:
             raise ConfigEntryNotReady

--- a/custom_components/cool_open_integration/config_flow.py
+++ b/custom_components/cool_open_integration/config_flow.py
@@ -18,6 +18,7 @@ from homeassistant.helpers.schema_config_entry_flow import (
 from collections.abc import Mapping
 
 from cool_open_client.cool_automation_client import CoolAutomationClient
+from homeassistant.util.ssl import client_context
 
 from .const import DOMAIN, TITLE
 
@@ -42,12 +43,17 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
     Data has the keys from STEP_USER_DATA_SCHEMA with values provided by the user.
     """
 
-    token = await CoolAutomationClient.authenticate(data["username"], data["password"])
+    ssl_ctx = await hass.async_add_executor_job(client_context)
+    token = await CoolAutomationClient.authenticate(
+        data["username"], data["password"], ssl_context=ssl_ctx
+    )
 
     if token == "Unauthorized":
         raise InvalidAuth
 
-    api: CoolAutomationClient = await CoolAutomationClient.create(token, logger=_LOGGER)
+    api: CoolAutomationClient = await CoolAutomationClient.create(
+        token, logger=_LOGGER, ssl_context=ssl_ctx
+    )
     me = await api.get_me()
 
     return {

--- a/custom_components/cool_open_integration/coordinator.py
+++ b/custom_components/cool_open_integration/coordinator.py
@@ -31,15 +31,33 @@ class CoolAutomationDataUpdateCoordinator(DataUpdateCoordinator):
         super().__init__(hass, _LOGGER, name=DOMAIN, update_interval=timedelta(seconds=POLL_INTERVAL))
 
     async def _async_update_data(self):
-        """Fetch data from Coolmaster."""
+        """Fetch data from Coolmaster.
+
+        Issues a single bulk request for all units and distributes the
+        resulting UnitUpdateMessage objects to the in-memory HVACUnit
+        instances. Replaces the previous per-unit fan-out which caused
+        excessive API traffic on large installations.
+        """
         try:
-            data = {}
-            for unit in self.units:
-                await unit.refresh()
-                data[unit.id] = unit
-                unit.reset_update()
+            updates = await self._client.get_updated_controllable_units()
         except OSError as error:
             raise UpdateFailed from error
+        except Exception as error:
+            # Surface as UpdateFailed so HA keeps the last known good data
+            # instead of blanking entities. Token expiry and transport
+            # failures both land here (same surface as the prior code).
+            raise UpdateFailed(f"Bulk unit update failed: {error}") from error
+
+        data: dict[str, HVACUnit] = {}
+        for unit in self.units:
+            message = updates.get(unit.id)
+            if message is not None:
+                # with_callback=False matches the prior unit.refresh() behaviour:
+                # the coordinator notifies listeners itself.
+                unit._update_unit(message, with_callback=False)
+            # A unit absent from the bulk response keeps its last-known state.
+            data[unit.id] = unit
+            unit.reset_update()
         return data
 
     @property

--- a/custom_components/cool_open_integration/manifest.json
+++ b/custom_components/cool_open_integration/manifest.json
@@ -11,9 +11,9 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/ShayGus/cool-open-integration/issues",
   "requirements": [
-    "cool-open-client==0.0.18"
+    "cool-open-client==0.0.19"
   ],
   "ssdp": [],
-  "version": "0.0.14",
+  "version": "0.0.15",
   "zeroconf": []
 }

--- a/custom_components/cool_open_integration/manifest.json
+++ b/custom_components/cool_open_integration/manifest.json
@@ -11,9 +11,9 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/ShayGus/cool-open-integration/issues",
   "requirements": [
-    "cool-open-client==0.0.19"
+    "cool-open-client==0.0.20"
   ],
   "ssdp": [],
-  "version": "0.0.15",
+  "version": "0.0.16",
   "zeroconf": []
 }

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+asyncio_mode = auto
+testpaths = tests

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,0 +1,3 @@
+pytest>=8.0
+pytest-asyncio>=0.23
+pytest-homeassistant-custom-component>=0.13

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,15 @@
+"""Shared pytest fixtures for the cool_open_integration tests."""
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def auto_enable_custom_integrations(enable_custom_integrations):
+    """Auto-enable custom_components for every test in this directory.
+
+    `enable_custom_integrations` is a fixture supplied by
+    `pytest-homeassistant-custom-component`. Wrapping it in an autouse
+    fixture lets every test pick it up without listing it explicitly.
+    """
+    yield

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,0 +1,51 @@
+"""Tests for CoolAutomationDataUpdateCoordinator.
+
+These tests stub the cool_open_client surface used by the coordinator so
+no HTTP calls are made.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.cool_open_integration.coordinator import (
+    CoolAutomationDataUpdateCoordinator,
+)
+
+
+def _make_unit(unit_id: str):
+    """Return a stub HVACUnit with the surface the coordinator touches."""
+    unit = MagicMock()
+    unit.id = unit_id
+    unit._update_unit = MagicMock()
+    unit.reset_update = MagicMock()
+    return unit
+
+
+def _make_update_message(unit_id: str):
+    """Return a stub UnitUpdateMessage; identity is enough for our tests."""
+    return SimpleNamespace(unit_id=unit_id)
+
+
+@pytest.mark.asyncio
+async def test_one_bulk_call_per_cycle_regardless_of_unit_count(hass):
+    units = [_make_unit(f"unit-{i}") for i in range(100)]
+    client = MagicMock()
+    client.get_updated_controllable_units = AsyncMock(
+        return_value={u.id: _make_update_message(u.id) for u in units}
+    )
+    # Per-unit fetcher must not be called by the new path.
+    client.get_updated_controllable_unit = AsyncMock()
+
+    entry = MagicMock()
+    coordinator = CoolAutomationDataUpdateCoordinator(hass, entry, client, units)
+
+    data = await coordinator._async_update_data()
+
+    assert client.get_updated_controllable_units.await_count == 1
+    assert client.get_updated_controllable_unit.await_count == 0
+    assert set(data.keys()) == {u.id for u in units}
+    for unit in units:
+        unit._update_unit.assert_called_once()

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -49,3 +49,49 @@ async def test_one_bulk_call_per_cycle_regardless_of_unit_count(hass):
     assert set(data.keys()) == {u.id for u in units}
     for unit in units:
         unit._update_unit.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_entity_identity_preserved_across_refresh(hass):
+    units = [_make_unit("unit-A"), _make_unit("unit-B")]
+    original_a, original_b = units[0], units[1]
+    client = MagicMock()
+    client.get_updated_controllable_units = AsyncMock(
+        return_value={
+            "unit-A": _make_update_message("unit-A"),
+            "unit-B": _make_update_message("unit-B"),
+        }
+    )
+
+    entry = MagicMock()
+    coordinator = CoolAutomationDataUpdateCoordinator(hass, entry, client, units)
+
+    data = await coordinator._async_update_data()
+
+    # Same object identity — entities hold references and must not be invalidated.
+    assert data["unit-A"] is original_a
+    assert data["unit-B"] is original_b
+    # And _update_unit was invoked for each (mutation path preserved).
+    original_a._update_unit.assert_called_once()
+    original_b._update_unit.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_missing_unit_in_bulk_response_keeps_last_known_state(hass):
+    units = [_make_unit("unit-A"), _make_unit("unit-B")]
+    client = MagicMock()
+    # Only unit-A is in the bulk response; unit-B is omitted.
+    client.get_updated_controllable_units = AsyncMock(
+        return_value={"unit-A": _make_update_message("unit-A")}
+    )
+
+    entry = MagicMock()
+    coordinator = CoolAutomationDataUpdateCoordinator(hass, entry, client, units)
+
+    data = await coordinator._async_update_data()
+
+    # Both units present, no exception raised.
+    assert set(data.keys()) == {"unit-A", "unit-B"}
+    # unit-A got an update; unit-B did NOT have _update_unit called.
+    units[0]._update_unit.assert_called_once()
+    units[1]._update_unit.assert_not_called()


### PR DESCRIPTION
## Summary

Two-part fix in response to CoolAutomation's report of excessive API traffic from this integration:

- **Bulk polling.** Rewrites `CoolAutomationDataUpdateCoordinator._async_update_data` to issue a single bulk HTTP call per 30-second cycle (via `cool-open-client`'s new `get_updated_controllable_units`) instead of fan-out per unit. Cuts request volume from O(N) to O(1). For the 87-unit commercial site flagged by CoolAutomation that's ~250K requests/day → ~2,880 — a >98% reduction. Behaviour preserved: 30s cadence (`POLL_INTERVAL` unchanged), `HVACUnit` instance identity (entities mutated in place), `iot_class: cloud_polling` (push updates are a follow-up release).
- **HA-friendly SSL context.** The library used to construct its `SSLContext` synchronously inside `RESTClientObject.__init__`, which reads the system CA bundle from disk and triggered HA's `Detected blocking call to load_default_certs ... by custom integration cool_open_integration` warnings on every config flow and entry setup. The integration now fetches HA's shared, pre-built context via `homeassistant.util.ssl.client_context()` (called once per entry-point through `hass.async_add_executor_job`) and passes it into every `authenticate` / `create` / `HVACUnitsFactory.create` call. Requires `cool-open-client>=0.0.20`.

## Changes

- `coordinator.py`: `_async_update_data` calls `client.get_updated_controllable_units()` once, distributes the resulting `UnitUpdateMessage`s to in-memory `HVACUnit` instances via `_update_unit(msg, with_callback=False)`. Missing units keep their last-known state.
- `__init__.py`, `config_flow.py`: get HA's pre-built SSL context off the event loop, pass `ssl_context=` to every library call site.
- `manifest.json`: pin `cool-open-client==0.0.20`, version `0.0.14 → 0.0.16`.
- `tests/` (new): pytest scaffold + three coordinator tests covering bulk fan-out (one HTTP call regardless of unit count), entity identity preservation, and missing-unit tolerance. `requirements_test.txt`, `pytest.ini`, `conftest.py`.

## Test plan

- [ ] `pytest tests/ -v` — 3/3 coordinator tests pass.
- [ ] Manual smoke test on a real HA instance (already performed): one `units_get` bulk call per 30s, **no** per-unit `units/{id}` calls. Climate entity state updates correctly when changed from the UI. No more `load_default_certs` / `set_default_verify_paths` warnings during config flow or coordinator setup.

## Out of scope

- Push updates via WebSocket (planned Step 2).
- WebSocket message-handling bugs flagged in cool-open-client PR #2 (review independently).

## Compatibility

- Existing config entries: unaffected (no schema changes).
- HACS upgrade path: bumping to `0.0.16` will pull `cool-open-client==0.0.20` from PyPI automatically.
- Python 3.12+: works (PR #7 already fixed the strict-int validation crash; this branch sits on top of merged PR #7).