### PR TITLE
Add design specs and implementation plans (Steps 1, 1.5, 2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,112 @@
+# cool-open-integration — Claude project guide
+
+Home Assistant custom integration for the CoolAutomation cloud platform (iocControl). HACS-distributed under `@ShayGus`.
+
+## Architecture
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│  custom_components/cool_open_integration/                        │
+│                                                                  │
+│  __init__.py        Entry setup. Starts the WS pump background  │
+│                     task that consumes the library's async       │
+│                     iterator and routes events to the coordinator│
+│                                                                  │
+│  coordinator.py     DataUpdateCoordinator. Bulk poll at 5-min    │
+│                     reconciliation cadence (RECONCILE_INTERVAL_  │
+│                     MINUTES). Mutates HVACUnit instances in      │
+│                     place and notifies entities.                 │
+│                                                                  │
+│  climate.py         ClimateEntity per HVACUnit.                  │
+│  config_flow.py     Username/password auth → token.              │
+│  entity.py          CoordinatorEntity base.                      │
+│  const.py           DOMAIN, PLATFORMS, RECONCILE_INTERVAL_MINUTES│
+└──────────────────────────────────────────────────────────────────┘
+                              ▲
+                              │ depends on
+                              ▼
+┌──────────────────────────────────────────────────────────────────┐
+│  cool-open-client (PyPI dep, pinned in manifest.json)            │
+│                                                                  │
+│  CoolAutomationClient.subscribe_unit_updates()                   │
+│      → AsyncIterator[UnitUpdate | Reconnected]                   │
+│  CoolAutomationClient.get_updated_controllable_units()           │
+│      → dict[unit_id, UnitUpdateMessage]  (used by reconcile poll)│
+└──────────────────────────────────────────────────────────────────┘
+```
+
+Two update channels feed one coordinator:
+
+1. **WS pump (primary)** — `_ws_pump` in `__init__.py` reads
+   `subscribe_unit_updates()` forever. Each `UnitUpdate` mutates the
+   matching `HVACUnit` and pushes via `async_set_updated_data`. Each
+   `Reconnected` triggers an immediate `async_request_refresh`.
+2. **Reconciliation poll (safety net)** — `_async_update_data` issues
+   one bulk HTTP call every 5 minutes, distributes the result to in-
+   memory units. Catches drift if the WS missed messages.
+
+`iot_class: cloud_push`.
+
+## Repo layout
+
+| Path | Purpose |
+|---|---|
+| `custom_components/cool_open_integration/` | The integration itself |
+| `tests/` | Pytest scaffold using `pytest-homeassistant-custom-component`. Run with `.venv-test/bin/pytest tests/`. |
+| `docs/superpowers/specs/` | Design docs for past initiatives (traffic reduction, WS push) |
+| `docs/superpowers/plans/` | Task-level implementation plans for the same |
+| `config/` (mounted into devcontainer) | HA's config dir used during local development |
+
+## Companion library
+
+The integration depends on [`cool-open-client`](https://pypi.org/project/cool-open-client/), maintained in a sibling repo at `../CoolControlOpenClient/` (host path) / `/coc/` (devcontainer mount). The library version is pinned in `manifest.json` `requirements`; bump in lockstep when the library changes.
+
+## Development
+
+Inside the HA dev container (defined at `core/.devcontainer/devcontainer.json`):
+
+```bash
+# Install the library wheel from the mounted path (no need to copy):
+pip install --force-reinstall /coc/dist/cool_open_client-X.Y.Z-py3-none-any.whl
+
+# Run integration tests outside the container:
+cd /home/shayg/projects/HomeAssistant/cool-open-integration
+.venv-test/bin/pytest tests/ -v
+```
+
+Integration source is bind-mounted into the container at `/workspaces/core/config/custom_components/cool_open_integration` — edits land live without copying. Restart HA to pick them up.
+
+## Release flow
+
+1. **Library** (`cool-open-client`):
+   - Bump `setup.py`, build wheel, commit, tag `vX.Y.Z`, push.
+   - Open PR against `master`, merge.
+   - Publish to PyPI: clean `dist/` of older versions, then
+     `pipx run --spec 'twine>=6.1' twine upload --non-interactive -u __token__ -p "$(< pypi-token.txt)" dist/cool_open_client-X.Y.Z*`.
+2. **Integration** (this repo):
+   - Bump `manifest.json` `requirements` pin and `version`. Commit.
+   - Open PR against `main`, merge.
+   - `git tag X.Y.Z && git push origin X.Y.Z`.
+   - **`gh release create X.Y.Z --title X.Y.Z --notes "..."`** — HACS picks
+     up GitHub Releases, not just tags. Easy to forget.
+
+## Known constraints / non-obvious behaviour
+
+- Token refresh during a live WS session is out of scope. On token
+  expiry, the library backs off forever; the user must reload the
+  config entry to trigger reauth.
+- Units added or removed mid-session won't surface as entities until
+  the entry is reloaded. The WS pump builds `units_by_id` once at
+  setup; the reconciliation poll sees state changes but doesn't add
+  new entities.
+- `HVACUnit._update_unit` is a leading-underscore "private" method on
+  the library, called from this integration. If the library refactors
+  the message-apply API in future, this call site needs updating.
+- The `with_callback` parameter on `_update_unit` was removed in
+  `cool-open-client 0.0.21`. Callers must not pass it.
+
+## Past initiatives
+
+- **Step 1** (0.0.15) — Replaced per-unit polling with one bulk call per cycle. ~99% traffic drop. Spec: `docs/superpowers/specs/2026-05-20-cool-open-api-traffic-reduction-design.md`.
+- **Step 1.5** (0.0.16) — Threaded HA's pre-built SSL context through the library to fix `Detected blocking call to load_default_certs` warnings.
+- **Step 2** (0.0.17) — Added WebSocket-driven push updates. `iot_class: cloud_push`. Spec: `docs/superpowers/specs/2026-05-20-cool-open-websocket-push-design.md`.

--- a/README.md
+++ b/README.md
@@ -6,3 +6,9 @@ This is an open source integration for the CoolMaster online cloud service. In o
 In Order to use this integration, your devices need to be registered with iocControl and you need to have a valid username and password for the service.
 
 When installing the integration all of your controllable units will be added to Home Assistant. Currently the integration only supports HVAC units and doesn't support water heaters.
+
+## How it works
+
+The integration uses CoolAutomation's WebSocket API for real-time updates. When a unit's state changes — including changes made from a wall remote or another app — the new state appears in Home Assistant within a couple of seconds. A bulk HTTP poll runs every five minutes as a drift safety net.
+
+For contributors and maintainers, see [CLAUDE.md](CLAUDE.md) for architecture and release flow.

--- a/docs/superpowers/plans/2026-05-20-cool-open-api-traffic-reduction-step1.md
+++ b/docs/superpowers/plans/2026-05-20-cool-open-api-traffic-reduction-step1.md
@@ -1,0 +1,931 @@
+# Cool Open API Traffic Reduction — Step 1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace per-unit polling in `cool-open-integration` with one bulk
+HTTP call per cycle, cutting API traffic by ~99% for the hotel customer
+flagged by CoolAutomation.
+
+**Architecture:** Add a symmetrical bulk method
+`CoolAutomationClient.get_updated_controllable_units()` to the
+`cool-open-client` library (returns `dict[unit_id, UnitUpdateMessage]`), then
+rewrite the integration's `DataUpdateCoordinator._async_update_data` to call
+it once per cycle and mutate existing `HVACUnit` instances in place. Polling
+cadence (30s), entity identity, and `iot_class: cloud_polling` are preserved.
+WebSocket adoption is deferred to Step 2.
+
+**Tech Stack:** Python 3.12+, aiohttp, `cool-open-client` (PyPI),
+`homeassistant`, `pytest-homeassistant-custom-component`,
+`unittest.IsolatedAsyncioTestCase`.
+
+**Spec:** `docs/superpowers/specs/2026-05-20-cool-open-api-traffic-reduction-design.md`
+
+---
+
+## Repository layout
+
+Two repos, must ship together:
+
+- **Library** — `CoolControlOpenClient/` (PyPI package `cool-open-client`)
+- **Integration** — `cool-open-integration/` (HA custom component)
+
+The library changes ship first (`0.0.18 → 0.0.19`), then the integration pins
+to the new version (`0.0.14 → 0.0.15`).
+
+## File structure
+
+**Library (`CoolControlOpenClient/`):**
+
+| File | Change | Purpose |
+|---|---|---|
+| `cool_open_client/utils/units_payload.py` | Create | Module-level `extract_units_mapping`, `ensure_dict` helpers lifted from `HVACUnitsFactory` so the new client method and the factory share parsing |
+| `cool_open_client/hvac_units_factory.py` | Modify | Replace the two private static methods with imports from `utils/units_payload` |
+| `cool_open_client/cool_automation_client.py` | Modify | Add `get_updated_controllable_units` method |
+| `tests/test_get_updated_controllable_units.py` | Create | Mocked async test (no live API) for the new method |
+| `setup.py` | Modify | Version `0.0.18 → 0.0.19` |
+
+**Integration (`cool-open-integration/`):**
+
+| File | Change | Purpose |
+|---|---|---|
+| `tests/__init__.py` | Create | Make tests a package |
+| `tests/conftest.py` | Create | `pytest-homeassistant-custom-component` fixtures + `enable_custom_integrations` autouse |
+| `tests/test_coordinator.py` | Create | Three coordinator tests: bulk fan-out, entity identity, missing-unit tolerance |
+| `requirements_test.txt` | Create | Pin `pytest-homeassistant-custom-component` |
+| `custom_components/cool_open_integration/coordinator.py` | Modify | Rewrite `_async_update_data` to use the bulk method |
+| `custom_components/cool_open_integration/manifest.json` | Modify | Pin `cool-open-client==0.0.19`, bump `version` to `0.0.15` |
+
+---
+
+## Task ordering rationale
+
+TDD-ordered with library work first since the integration imports from it.
+Refactor before adding new code (Task 1) so the new method can use shared
+helpers without duplicating logic. Each task ends with a commit on the
+appropriate repo's main branch (or a feature branch — author's choice).
+
+---
+
+## Task 1: Lift shared payload helpers to a module
+
+**Files:**
+- Create: `CoolControlOpenClient/cool_open_client/utils/units_payload.py`
+- Modify: `CoolControlOpenClient/cool_open_client/hvac_units_factory.py`
+
+This is a pure refactor — no behavior change. We move two private helpers
+out of `HVACUnitsFactory` so the new client method (Task 2) can reuse them
+without duplicating the defensive payload-parsing logic.
+
+- [ ] **Step 1: Create the helpers module**
+
+Create `CoolControlOpenClient/cool_open_client/utils/units_payload.py`:
+
+```python
+"""Shared helpers for parsing the `UnitsResponse` payload shape.
+
+Lifted from `HVACUnitsFactory` so both the factory (setup-time) and the
+client's bulk update method (poll-time) parse the API response with the
+same defensive logic.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+def extract_units_mapping(payload: Any) -> Dict[str, Any]:
+    """Return a `{unit_id: payload}` mapping from a `UnitsResponse.data` value."""
+    if payload is None:
+        return {}
+    if isinstance(payload, dict):
+        return payload
+    additional = getattr(payload, "additional_properties", None)
+    if isinstance(additional, dict):
+        return additional
+    if hasattr(payload, "to_dict"):
+        dumped = payload.to_dict()
+        if isinstance(dumped, dict):
+            return dumped
+    return {}
+
+
+def ensure_dict(payload: Any) -> Dict[str, Any]:
+    """Coerce a single-unit payload into a plain dict."""
+    if isinstance(payload, dict):
+        return payload
+    if hasattr(payload, "model_dump"):
+        dumped = payload.model_dump(by_alias=True, exclude_none=True)
+        if isinstance(dumped, dict):
+            return dumped
+    if hasattr(payload, "to_dict"):
+        dumped = payload.to_dict()
+        if isinstance(dumped, dict):
+            return dumped
+    return {}
+```
+
+- [ ] **Step 2: Refactor `HVACUnitsFactory` to import the helpers**
+
+In `CoolControlOpenClient/cool_open_client/hvac_units_factory.py`:
+
+1. Add at the top of the file (after existing imports):
+
+```python
+from .utils.units_payload import ensure_dict, extract_units_mapping
+```
+
+2. In `generate_units_from_api`, replace the call site
+   `units_payload = self._extract_mapping(units.data)` with
+   `units_payload = extract_units_mapping(units.data)`.
+
+3. In `generate_units_from_api`, replace `raw_unit = self._ensure_dict(payload)` with
+   `raw_unit = ensure_dict(payload)`.
+
+4. **Delete** the two static methods `_extract_mapping` and `_ensure_dict` from
+   `HVACUnitsFactory`. (Search for `@staticmethod` blocks defining those names
+   and remove their bodies entirely. They are no longer referenced.)
+
+- [ ] **Step 3: Run the existing factory tests to verify no regression**
+
+Run from `CoolControlOpenClient/`:
+
+```bash
+python -m unittest tests.test_hvac_units_factory -v
+```
+
+Expected: same pass/skip status as before the refactor (any tests that
+required a `token.txt` fixture will still skip cleanly).
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd CoolControlOpenClient
+git add cool_open_client/utils/units_payload.py cool_open_client/hvac_units_factory.py
+git commit -m "refactor: lift units payload helpers to a shared module"
+```
+
+---
+
+## Task 2: Add `get_updated_controllable_units` to the client
+
+**Files:**
+- Modify: `CoolControlOpenClient/cool_open_client/cool_automation_client.py`
+- Create: `CoolControlOpenClient/tests/test_get_updated_controllable_units.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `CoolControlOpenClient/tests/test_get_updated_controllable_units.py`:
+
+```python
+from __future__ import annotations
+
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+try:
+    from cool_open_client.cool_automation_client import (
+        CoolAutomationClient,
+        UnitUpdateMessage,
+    )
+    from cool_open_client.utils.singleton import SingletonMeta
+except ModuleNotFoundError as exc:
+    if exc.name == "websocket":
+        raise unittest.SkipTest("websocket-client dependency missing")
+    raise
+
+
+class GetUpdatedControllableUnitsTest(unittest.IsolatedAsyncioTestCase):
+    """Unit tests for the new bulk-update client method. No live API."""
+
+    async def asyncSetUp(self):
+        # Bypass CoolAutomationClient.create() so we don't need a real token.
+        SingletonMeta._instances.pop(CoolAutomationClient, None)
+        self.client = CoolAutomationClient.__new__(CoolAutomationClient)
+        self.client.token = "test-token"
+        self.client.api_client = MagicMock()
+        self.client.api_client.close = AsyncMock()
+        # Minimal dictionary stubs (`_transform_message` reads these).
+        self.client.fan_modes = MagicMock(get=lambda v: v)
+        self.client.operation_modes = MagicMock(get=lambda v: v)
+        self.client.operation_statuses = MagicMock(get=lambda v: v)
+        self.client.swing_modes = MagicMock(get=lambda v: v)
+
+    async def asyncTearDown(self):
+        await self.client.api_client.close()
+        SingletonMeta._instances.pop(CoolAutomationClient, None)
+
+    async def test_returns_message_per_unit(self):
+        fake_response = MagicMock()
+        fake_response.data = {
+            "unit-A": {
+                "id": "unit-A",
+                "name": "Lobby",
+                "type": 1,
+                "active_fan_mode": 1,
+                "active_operation_mode": 2,
+                "active_operation_status": 1,
+                "active_setpoint": 22.0,
+                "active_swing_mode": 0,
+                "ambient_temperature": 23,
+                "filter": False,
+            },
+            "unit-B": {
+                "id": "unit-B",
+                "name": "Suite 101",
+                "type": 1,
+                "active_fan_mode": 2,
+                "active_operation_mode": 1,
+                "active_operation_status": 1,
+                "active_setpoint": 20.0,
+                "active_swing_mode": 1,
+                "ambient_temperature": 21,
+                "filter": False,
+            },
+        }
+        with patch(
+            "cool_open_client.cool_automation_client.UnitsApi"
+        ) as fake_units_api_cls:
+            fake_units_api = fake_units_api_cls.return_value
+            fake_units_api.units_get = AsyncMock(return_value=fake_response)
+
+            result = await self.client.get_updated_controllable_units()
+
+        self.assertEqual(set(result.keys()), {"unit-A", "unit-B"})
+        for message in result.values():
+            self.assertIsInstance(message, UnitUpdateMessage)
+        self.assertEqual(result["unit-A"].unit_id, "unit-A")
+        # One bulk HTTP call total — the whole point of the new method.
+        self.assertEqual(fake_units_api.units_get.await_count, 1)
+
+    async def test_skips_non_controllable_types(self):
+        fake_response = MagicMock()
+        fake_response.data = {
+            "unit-A": {"id": "unit-A", "type": 1, "active_setpoint": 22.0},
+            "device-X": {"id": "device-X", "type": 2},  # not a unit
+        }
+        with patch(
+            "cool_open_client.cool_automation_client.UnitsApi"
+        ) as fake_units_api_cls:
+            fake_units_api = fake_units_api_cls.return_value
+            fake_units_api.units_get = AsyncMock(return_value=fake_response)
+
+            result = await self.client.get_updated_controllable_units()
+
+        self.assertIn("unit-A", result)
+        self.assertNotIn("device-X", result)
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run from `CoolControlOpenClient/`:
+
+```bash
+python -m unittest tests.test_get_updated_controllable_units -v
+```
+
+Expected: FAIL with `AttributeError: 'CoolAutomationClient' object has no attribute 'get_updated_controllable_units'` (or test errors of that shape).
+
+- [ ] **Step 3: Add the method**
+
+In `CoolControlOpenClient/cool_open_client/cool_automation_client.py`:
+
+1. Add imports near the top (alongside the existing `from .utils.dict_to_model import dict_to_model`):
+
+```python
+from .utils.units_payload import ensure_dict, extract_units_mapping
+```
+
+2. Locate `async def get_updated_controllable_unit(self, unit_id: str)` (the existing per-unit method) and insert this method directly below it:
+
+```python
+    @with_exception
+    async def get_updated_controllable_units(self) -> dict[str, UnitUpdateMessage]:
+        """
+        Bulk equivalent of `get_updated_controllable_unit`.
+
+        Issues a single HTTP request and returns a mapping of
+        `unit_id -> UnitUpdateMessage` for every controllable unit
+        (those with `type` in `(None, 1)`). Mirrors the transformation
+        applied by the per-unit method so callers can feed the messages
+        straight into `HVACUnit._update_unit`.
+        """
+        api = UnitsApi(api_client=self.api_client)
+        response: UnitsResponse = await api.units_get(
+            x_access_token=self.token,
+            origin=self.ORIGIN,
+            referer=self.REFERER,
+        )
+
+        updates: dict[str, UnitUpdateMessage] = {}
+        payload = extract_units_mapping(response.data)
+
+        for unit_id, raw in payload.items():
+            raw_dict = ensure_dict(raw)
+            # Match HVACUnitsFactory's filter exactly: applied to the raw
+            # dict, before model construction, so we don't waste work on
+            # entries the factory itself would skip.
+            if isinstance(raw_dict, dict) and raw_dict.get("type") not in (None, 1):
+                continue
+            try:
+                unit = dict_to_model(UnitResponseData, raw)
+            except TypeError:
+                continue
+
+            message = UnitUpdateMessage(
+                ambient_temperature=round_temperature_value(unit.ambient_temperature),
+                fan_mode=unit.active_fan_mode,
+                operation_mode=unit.active_operation_mode,
+                setpoint=round_temperature_value(unit.active_setpoint),
+                swing=unit.active_swing_mode,
+                operation_status=unit.active_operation_status,
+                filter=unit.filter,
+                unit_id=unit.id or unit_id,
+            )
+            updates[message.unit_id] = self._transform_message(message)
+
+        return updates
+```
+
+3. If `UnitResponseData` is not already imported at the top of the file, add:
+
+```python
+from .client.models.unit_response_data import UnitResponseData
+```
+
+(Check the existing imports first — `get_updated_controllable_unit` already
+uses `UnitResponseData` directly via the per-unit path, so it may already be
+imported.)
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run from `CoolControlOpenClient/`:
+
+```bash
+python -m unittest tests.test_get_updated_controllable_units -v
+```
+
+Expected: both tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd CoolControlOpenClient
+git add cool_open_client/cool_automation_client.py tests/test_get_updated_controllable_units.py
+git commit -m "feat: add get_updated_controllable_units bulk method"
+```
+
+---
+
+## Task 3: Bump library version
+
+**Files:**
+- Modify: `CoolControlOpenClient/setup.py`
+
+- [ ] **Step 1: Bump the version**
+
+In `CoolControlOpenClient/setup.py`, find the line `version="0.0.18",` and
+change it to:
+
+```python
+    version="0.0.19",
+```
+
+- [ ] **Step 2: Verify the package still builds**
+
+Run from `CoolControlOpenClient/`:
+
+```bash
+python -m build --sdist --wheel --outdir dist/
+```
+
+Expected: builds succeed, produces `dist/cool_open_client-0.0.19*` artifacts.
+
+(If `build` is not available, install it once: `pip install build`.)
+
+- [ ] **Step 3: Commit and tag**
+
+```bash
+cd CoolControlOpenClient
+git add setup.py
+git commit -m "chore: bump cool-open-client to 0.0.19"
+git tag v0.0.19
+```
+
+- [ ] **Step 4: Publish to PyPI** *(performed by the maintainer; not by an automated agent)*
+
+```bash
+cd CoolControlOpenClient
+python -m twine upload dist/cool_open_client-0.0.19*
+```
+
+This is a human-in-the-loop step. Confirm the new version is visible at
+<https://pypi.org/project/cool-open-client/> before moving to Task 4.
+
+---
+
+## Task 4: Set up the integration test scaffold
+
+**Files:**
+- Create: `cool-open-integration/requirements_test.txt`
+- Create: `cool-open-integration/tests/__init__.py`
+- Create: `cool-open-integration/tests/conftest.py`
+
+The integration has zero tests today. Establish the minimum needed to write
+the coordinator tests in Task 5.
+
+- [ ] **Step 1: Create the test-requirements file**
+
+Create `cool-open-integration/requirements_test.txt`:
+
+```
+pytest>=8.0
+pytest-asyncio>=0.23
+pytest-homeassistant-custom-component>=0.13
+```
+
+- [ ] **Step 2: Install test requirements**
+
+Run from `cool-open-integration/`:
+
+```bash
+pip install -r requirements_test.txt
+```
+
+- [ ] **Step 3: Create the tests package marker**
+
+Create `cool-open-integration/tests/__init__.py` (empty file).
+
+- [ ] **Step 4: Create the conftest**
+
+Create `cool-open-integration/tests/conftest.py`:
+
+```python
+"""Shared pytest fixtures for the cool_open_integration tests."""
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def auto_enable_custom_integrations(enable_custom_integrations):
+    """Auto-enable custom_components for every test in this directory.
+
+    `enable_custom_integrations` is a fixture supplied by
+    `pytest-homeassistant-custom-component`. Wrapping it in an autouse
+    fixture lets every test pick it up without listing it explicitly.
+    """
+    yield
+```
+
+- [ ] **Step 5: Run pytest collection to confirm the scaffold works**
+
+Run from `cool-open-integration/`:
+
+```bash
+pytest tests/ --collect-only -q
+```
+
+Expected: collection succeeds with 0 tests collected (no tests yet).
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd cool-open-integration
+git add requirements_test.txt tests/__init__.py tests/conftest.py
+git commit -m "test: add pytest scaffolding for the integration"
+```
+
+---
+
+## Task 5: Coordinator test — bulk fan-out
+
+**Files:**
+- Create: `cool-open-integration/tests/test_coordinator.py`
+
+This test is written first and will fail. It encodes the contract we want:
+exactly one bulk HTTP call per cycle, regardless of how many units exist.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `cool-open-integration/tests/test_coordinator.py`:
+
+```python
+"""Tests for CoolAutomationDataUpdateCoordinator.
+
+These tests stub the cool_open_client surface used by the coordinator so
+no HTTP calls are made.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.cool_open_integration.coordinator import (
+    CoolAutomationDataUpdateCoordinator,
+)
+
+
+def _make_unit(unit_id: str):
+    """Return a stub HVACUnit with the surface the coordinator touches."""
+    unit = MagicMock()
+    unit.id = unit_id
+    unit._update_unit = MagicMock()
+    unit.reset_update = MagicMock()
+    return unit
+
+
+def _make_update_message(unit_id: str):
+    """Return a stub UnitUpdateMessage; identity is enough for our tests."""
+    return SimpleNamespace(unit_id=unit_id)
+
+
+@pytest.mark.asyncio
+async def test_one_bulk_call_per_cycle_regardless_of_unit_count(hass):
+    units = [_make_unit(f"unit-{i}") for i in range(100)]
+    client = MagicMock()
+    client.get_updated_controllable_units = AsyncMock(
+        return_value={u.id: _make_update_message(u.id) for u in units}
+    )
+    # Per-unit fetcher must not be called by the new path.
+    client.get_updated_controllable_unit = AsyncMock()
+
+    entry = MagicMock()
+    coordinator = CoolAutomationDataUpdateCoordinator(hass, entry, client, units)
+
+    data = await coordinator._async_update_data()
+
+    assert client.get_updated_controllable_units.await_count == 1
+    assert client.get_updated_controllable_unit.await_count == 0
+    assert set(data.keys()) == {u.id for u in units}
+    for unit in units:
+        unit._update_unit.assert_called_once()
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run from `cool-open-integration/`:
+
+```bash
+pytest tests/test_coordinator.py::test_one_bulk_call_per_cycle_regardless_of_unit_count -v
+```
+
+Expected: FAIL — current coordinator either calls `unit.refresh()` (which
+hits a missing per-unit endpoint on the mock) or, if the mock tolerates it,
+fails the `await_count == 1` assertion on `get_updated_controllable_units`.
+
+- [ ] **Step 3: (Do not implement yet — proceed to Task 6 for the rewrite.)**
+
+The implementation lives in Task 6 so the rewrite step has all three
+coordinator tests in front of it.
+
+---
+
+## Task 6: Rewrite the coordinator to use the bulk method
+
+**Files:**
+- Modify: `cool-open-integration/custom_components/cool_open_integration/coordinator.py`
+
+- [ ] **Step 1: Rewrite `_async_update_data`**
+
+Open `cool-open-integration/custom_components/cool_open_integration/coordinator.py`.
+
+Replace the entire `_async_update_data` method body so the file looks
+exactly like this (only the method body changes; class definition,
+imports, and `__init__` are unchanged):
+
+```python
+from __future__ import annotations
+
+from datetime import timedelta
+import logging
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from cool_open_client.cool_automation_client import CoolAutomationClient
+from cool_open_client.unit import HVACUnit
+
+from .const import DOMAIN, POLL_INTERVAL
+
+_LOGGER = logging.getLogger(__package__)
+
+
+class CoolAutomationDataUpdateCoordinator(DataUpdateCoordinator):
+    """Class to manage fetching Coolmaster data."""
+
+    data: dict[str, HVACUnit]
+
+    def __init__(
+        self, hass: HomeAssistant, entry: ConfigEntry, client: CoolAutomationClient, units: list[HVACUnit]
+    ) -> None:
+        """Initialize global Coolmaster data updater."""
+        _LOGGER.debug("Init Cool Automation update coordinator")
+        self._client = client
+        self.hass = hass
+        self.units = units
+
+        super().__init__(hass, _LOGGER, name=DOMAIN, update_interval=timedelta(seconds=POLL_INTERVAL))
+
+    async def _async_update_data(self):
+        """Fetch data from Coolmaster.
+
+        Issues a single bulk request for all units and distributes the
+        resulting `UnitUpdateMessage` objects to the in-memory `HVACUnit`
+        instances. Replaces the previous per-unit fan-out which caused
+        excessive API traffic on large installations.
+        """
+        try:
+            updates = await self._client.get_updated_controllable_units()
+        except OSError as error:
+            raise UpdateFailed from error
+        except Exception as error:  # noqa: BLE001 — surface as UpdateFailed
+            raise UpdateFailed(f"Bulk unit update failed: {error}") from error
+
+        data: dict[str, HVACUnit] = {}
+        for unit in self.units:
+            message = updates.get(unit.id)
+            if message is not None:
+                # `with_callback=False` matches the prior `unit.refresh()`
+                # behaviour: the coordinator notifies listeners itself.
+                unit._update_unit(message, with_callback=False)
+            # A unit absent from the bulk response keeps its last-known
+            # state — same tolerance the previous code had for transient
+            # per-unit failures.
+            data[unit.id] = unit
+            unit.reset_update()
+        return data
+
+    @property
+    def client(self):
+        return self._client
+```
+
+- [ ] **Step 2: Run the bulk-call test to verify it passes**
+
+Run from `cool-open-integration/`:
+
+```bash
+pytest tests/test_coordinator.py::test_one_bulk_call_per_cycle_regardless_of_unit_count -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd cool-open-integration
+git add custom_components/cool_open_integration/coordinator.py tests/test_coordinator.py
+git commit -m "feat: use bulk endpoint in coordinator (fixes traffic spike)"
+```
+
+---
+
+## Task 7: Coordinator test — entity identity preserved
+
+**Files:**
+- Modify: `cool-open-integration/tests/test_coordinator.py`
+
+- [ ] **Step 1: Add the test**
+
+Append to `cool-open-integration/tests/test_coordinator.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_entity_identity_preserved_across_refresh(hass):
+    units = [_make_unit("unit-A"), _make_unit("unit-B")]
+    original_a, original_b = units[0], units[1]
+    client = MagicMock()
+    client.get_updated_controllable_units = AsyncMock(
+        return_value={
+            "unit-A": _make_update_message("unit-A"),
+            "unit-B": _make_update_message("unit-B"),
+        }
+    )
+
+    entry = MagicMock()
+    coordinator = CoolAutomationDataUpdateCoordinator(hass, entry, client, units)
+
+    data = await coordinator._async_update_data()
+
+    # Same object identity — entities hold references and must not be invalidated.
+    assert data["unit-A"] is original_a
+    assert data["unit-B"] is original_b
+    # And `_update_unit` was invoked for each (mutation path preserved).
+    original_a._update_unit.assert_called_once()
+    original_b._update_unit.assert_called_once()
+```
+
+- [ ] **Step 2: Run the test to verify it passes**
+
+Run from `cool-open-integration/`:
+
+```bash
+pytest tests/test_coordinator.py::test_entity_identity_preserved_across_refresh -v
+```
+
+Expected: PASS (the rewrite from Task 6 already satisfies this contract).
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd cool-open-integration
+git add tests/test_coordinator.py
+git commit -m "test: lock entity identity contract across coordinator refresh"
+```
+
+---
+
+## Task 8: Coordinator test — missing-unit tolerance
+
+**Files:**
+- Modify: `cool-open-integration/tests/test_coordinator.py`
+
+- [ ] **Step 1: Add the test**
+
+Append to `cool-open-integration/tests/test_coordinator.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_missing_unit_in_bulk_response_keeps_last_known_state(hass):
+    units = [_make_unit("unit-A"), _make_unit("unit-B")]
+    client = MagicMock()
+    # Only unit-A is in the bulk response; unit-B is omitted.
+    client.get_updated_controllable_units = AsyncMock(
+        return_value={"unit-A": _make_update_message("unit-A")}
+    )
+
+    entry = MagicMock()
+    coordinator = CoolAutomationDataUpdateCoordinator(hass, entry, client, units)
+
+    data = await coordinator._async_update_data()
+
+    # Both units present, no exception raised.
+    assert set(data.keys()) == {"unit-A", "unit-B"}
+    # unit-A got an update; unit-B did NOT have _update_unit called.
+    units[0]._update_unit.assert_called_once()
+    units[1]._update_unit.assert_not_called()
+```
+
+- [ ] **Step 2: Run the test to verify it passes**
+
+Run from `cool-open-integration/`:
+
+```bash
+pytest tests/test_coordinator.py::test_missing_unit_in_bulk_response_keeps_last_known_state -v
+```
+
+Expected: PASS (the rewrite from Task 6 already satisfies this contract).
+
+- [ ] **Step 3: Run the full coordinator test file**
+
+Run from `cool-open-integration/`:
+
+```bash
+pytest tests/test_coordinator.py -v
+```
+
+Expected: all three tests PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd cool-open-integration
+git add tests/test_coordinator.py
+git commit -m "test: tolerate units missing from bulk update response"
+```
+
+---
+
+## Task 9: Bump integration requirement and version
+
+**Files:**
+- Modify: `cool-open-integration/custom_components/cool_open_integration/manifest.json`
+
+- [ ] **Step 1: Update `manifest.json`**
+
+Open `cool-open-integration/custom_components/cool_open_integration/manifest.json` and apply these two edits:
+
+1. In the `requirements` array, change
+   `"cool-open-client==0.0.18"` to
+   `"cool-open-client==0.0.19"`.
+
+2. Change the top-level `"version"` field from
+   `"0.0.14"` to
+   `"0.0.15"`.
+
+The file should look like (other fields untouched):
+
+```json
+{
+  "domain": "cool_open_integration",
+  "name": "CoolAutomation Cloud Open Integration",
+  "codeowners": ["@ShayGus"],
+  "config_flow": true,
+  "dependencies": [],
+  "documentation": "https://github.com/ShayGus/cool-open-integration/wiki",
+  "homekit": {},
+  "iot_class": "cloud_polling",
+  "issue_tracker": "https://github.com/ShayGus/cool-open-integration/issues",
+  "requirements": ["cool-open-client==0.0.19"],
+  "ssdp": [],
+  "version": "0.0.15",
+  "zeroconf": []
+}
+```
+
+- [ ] **Step 2: Re-run the test suite to confirm nothing broke**
+
+Run from `cool-open-integration/`:
+
+```bash
+pytest tests/ -v
+```
+
+Expected: all three tests PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd cool-open-integration
+git add custom_components/cool_open_integration/manifest.json
+git commit -m "chore: pin cool-open-client==0.0.19 and bump version to 0.0.15"
+```
+
+---
+
+## Task 10: Manual smoke test on a real Home Assistant install
+
+This is a human verification step — the automated tests cannot prove a real
+HTTP call goes to CoolAutomation's API. Do not skip.
+
+- [ ] **Step 1: Install the new integration version in a test HA instance**
+
+Copy `cool-open-integration/custom_components/cool_open_integration/` into
+your test HA's `custom_components/` directory (or pull via HACS once
+released). Make sure `pip` resolves `cool-open-client==0.0.19` — restart HA
+if it had the old version cached.
+
+- [ ] **Step 2: Enable DEBUG logging for the integration**
+
+Add to the test HA's `configuration.yaml`:
+
+```yaml
+logger:
+  default: warning
+  logs:
+    custom_components.cool_open_integration: debug
+    cool_open_client: debug
+```
+
+Restart HA.
+
+- [ ] **Step 3: Watch the logs for one full poll cycle**
+
+Tail the log:
+
+```bash
+tail -f /path/to/homeassistant.log | grep -Ei 'cool_open|units'
+```
+
+Wait ~35 seconds. You should see exactly one bulk request per cycle. Expect a log line confirming `get_updated_controllable_units` was called, and **no** repeated `get_updated_controllable_unit` (singular) calls.
+
+- [ ] **Step 4: Confirm climate entities still update**
+
+In the HA UI, change one of the climate entities' setpoint or operation
+mode via the integration. Confirm:
+
+1. The change is accepted (no error).
+2. Within ~30 seconds the entity reflects the new state.
+3. Other entities' states have not been blanked or duplicated.
+
+- [ ] **Step 5: Record the request rate**
+
+Note the number of HTTP requests logged to CoolAutomation in a 5-minute
+window. For a 10-unit install: expect ~10 requests (one bulk per 30s × 10
+cycles). Previously this would have been ~100.
+
+- [ ] **Step 6: Notify Adam**
+
+Send an update to `adam@coolautomation.com`:
+
+> Released `cool-open-integration` 0.0.15 with `cool-open-client` 0.0.19.
+> The integration now issues a single bulk request per 30-second cycle
+> instead of one per unit. Expected traffic shape: ~2,880 requests/day
+> per HA install regardless of unit count. The hotel customer (and any
+> commercial sites flagged) should see >98% reduction within 24 hours
+> as installs auto-update. Step 2 (WebSocket-driven push updates) is in
+> design and will land in a follow-up release.
+
+---
+
+## Done criteria
+
+- [ ] `cool-open-client==0.0.19` is on PyPI and includes
+  `get_updated_controllable_units`.
+- [ ] `cool-open-integration==0.0.15` is tagged, the manifest pins the new
+  client version, and the coordinator uses the bulk method.
+- [ ] All three coordinator tests pass under `pytest tests/`.
+- [ ] All library tests still pass (existing tests + the new mocked test).
+- [ ] Manual smoke test on a real account confirms one HTTP request per cycle.
+- [ ] Adam has been notified.

--- a/docs/superpowers/plans/2026-05-20-cool-open-websocket-push-step2.md
+++ b/docs/superpowers/plans/2026-05-20-cool-open-websocket-push-step2.md
@@ -1,0 +1,1242 @@
+# Cool Open WebSocket Push Updates — Step 2 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the integration's 30-second bulk polling with a push-driven coordinator backed by a new aiohttp-native WebSocket subscription in `cool-open-client`, and remove the legacy thread-based WS implementation.
+
+**Architecture:** A new async-generator method `CoolAutomationClient.subscribe_unit_updates()` yields `UnitUpdate` events from the CoolAutomation WS and `Reconnected` events after the library transparently reconnects. The HA integration runs the iterator in a background task that mutates `HVACUnit` instances in place and triggers `async_set_updated_data` per update or `async_request_refresh` per reconnect. The bulk poll from Step 1 stays but drops to a 5-minute reconciliation cadence.
+
+**Tech Stack:** Python 3.12+, `aiohttp` (already a transitive dep via the REST client; no new packages), `marshmallow_dataclass` (existing), `homeassistant`, `pytest-homeassistant-custom-component`, `unittest.IsolatedAsyncioTestCase`.
+
+**Spec:** `docs/superpowers/specs/2026-05-20-cool-open-websocket-push-design.md`
+
+---
+
+## Repository layout
+
+Two repos. Must ship together in this order: library `0.0.20 → 0.0.21` (PyPI) first, then integration `0.0.16 → 0.0.17` (HACS).
+
+- **Library** — `CoolControlOpenClient/`
+- **Integration** — `cool-open-integration/`
+
+## File structure
+
+**Library (`CoolControlOpenClient/`):**
+
+| File | Change | Purpose |
+|---|---|---|
+| `cool_open_client/ws_events.py` | Create | Frozen dataclasses: `UnitUpdate`, `Reconnected`. Type alias `WsEvent`. Single import point for the integration. |
+| `cool_open_client/cool_automation_client.py` | Modify | Add `subscribe_unit_updates` async generator. Remove `WebSocketThread`, `open_socket`, all `on_*_socket` handlers, `_handle_ping_pong`, `_handle_ws_message`, `register_for_updates`, `_registered_units`, `import websocket`. |
+| `cool_open_client/unit.py` | Modify | Remove `regiter_callback` (sic), `notify`, `_update_pending` machinery if unused after the strip. Keep `_update_unit` and `reset_update` (the integration's coordinator still calls them). |
+| `tests/test_subscribe_unit_updates.py` | Create | Four mocked tests covering the new method. |
+| `tests/test_websocket.py` | Delete | Live-API WS test for the removed thread-based implementation. |
+| `setup.py` | Modify | Remove `websocket-client` from `install_requires`. Bump version `0.0.20 → 0.0.21`. |
+| `requirements.txt` | Modify | Remove the `websocket-client` line. |
+
+**Integration (`cool-open-integration/`):**
+
+| File | Change | Purpose |
+|---|---|---|
+| `custom_components/cool_open_integration/__init__.py` | Modify | Spawn `_ws_pump` background task after coordinator first refresh. |
+| `custom_components/cool_open_integration/coordinator.py` | Modify | `update_interval` changes from `POLL_INTERVAL` seconds to `RECONCILE_INTERVAL` minutes. |
+| `custom_components/cool_open_integration/const.py` | Modify | Replace `POLL_INTERVAL = 30` with `RECONCILE_INTERVAL = 5`. |
+| `custom_components/cool_open_integration/manifest.json` | Modify | `iot_class: cloud_polling → cloud_push`; pin `cool-open-client==0.0.21`; version `0.0.16 → 0.0.17`. |
+| `tests/test_coordinator.py` | Modify | Append three new tests covering `_ws_pump` behaviour. |
+
+---
+
+## Task ordering rationale
+
+Add new before deleting old, so existing tests that reference the legacy WS code don't break mid-flight. TDD per task. Library finishes (and is locally rebuilt as a wheel) before any integration task runs.
+
+---
+
+## Task 1: Add WsEvent types
+
+**Files:**
+- Create: `CoolControlOpenClient/cool_open_client/ws_events.py`
+
+- [ ] **Step 1: Create the module**
+
+Create `CoolControlOpenClient/cool_open_client/ws_events.py`:
+
+```python
+"""Public event types yielded by `CoolAutomationClient.subscribe_unit_updates`."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Union
+
+if TYPE_CHECKING:
+    # Imported only for type checkers — runtime import would create a
+    # circular dependency with cool_automation_client.
+    from .cool_automation_client import UnitUpdateMessage
+
+
+@dataclass(frozen=True)
+class UnitUpdate:
+    """A real-time state change for a single HVAC unit.
+
+    Carries the same `UnitUpdateMessage` shape produced by the HTTP path's
+    `get_updated_controllable_unit` and `get_updated_controllable_units`,
+    so consumers can feed it directly into `HVACUnit._update_unit`.
+    """
+
+    message: "UnitUpdateMessage"
+
+
+@dataclass(frozen=True)
+class Reconnected:
+    """The WS connection dropped and was restored.
+
+    Consumers should reconcile state — one or more `UnitUpdate` messages
+    may have been missed during the gap.
+    """
+
+    pass
+
+
+WsEvent = Union[UnitUpdate, Reconnected]
+```
+
+- [ ] **Step 2: Smoke-test the import**
+
+Run from `CoolControlOpenClient/`:
+
+```bash
+python3 -c "from cool_open_client.ws_events import UnitUpdate, Reconnected, WsEvent; print('ok')"
+```
+
+Expected: `ok`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd CoolControlOpenClient
+git add cool_open_client/ws_events.py
+git commit -m "feat: add WsEvent types (UnitUpdate, Reconnected)"
+```
+
+---
+
+## Task 2: Add `subscribe_unit_updates` (failing tests first)
+
+**Files:**
+- Create: `CoolControlOpenClient/tests/test_subscribe_unit_updates.py`
+
+This task writes only the tests. The implementation lands in Task 3.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `CoolControlOpenClient/tests/test_subscribe_unit_updates.py`:
+
+```python
+"""Mocked tests for CoolAutomationClient.subscribe_unit_updates.
+
+No live API: aiohttp.ClientSession.ws_connect is patched to return a fake
+WS that delivers a scripted sequence of messages.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import unittest
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import aiohttp
+
+try:
+    from cool_open_client.cool_automation_client import CoolAutomationClient
+    from cool_open_client.utils.singleton import SingletonMeta
+    from cool_open_client.ws_events import Reconnected, UnitUpdate
+except ModuleNotFoundError as exc:
+    if exc.name == "websocket":
+        raise unittest.SkipTest("websocket-client dependency missing")
+    raise
+
+
+def _make_text_msg(payload: dict) -> MagicMock:
+    msg = MagicMock()
+    msg.type = aiohttp.WSMsgType.TEXT
+    msg.data = json.dumps(payload)
+    return msg
+
+
+class _FakeWs:
+    """Stand-in for aiohttp.ClientWebSocketResponse.
+
+    Scripted: returns each message from `incoming` in turn; raises
+    `terminate_with` after the script is exhausted (defaults to a closed
+    connection error so the library treats it as a disconnect).
+    """
+
+    def __init__(self, incoming, terminate_with=None):
+        self._incoming = list(incoming)
+        self._terminate = terminate_with or ConnectionResetError("script done")
+        self.sent = []
+        self.closed = False
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if not self._incoming:
+            raise self._terminate
+        return self._incoming.pop(0)
+
+    async def send_json(self, payload):
+        self.sent.append(payload)
+
+    async def close(self):
+        self.closed = True
+
+
+def _make_unit_update_payload(unit_id: str, setpoint: int = 22) -> dict:
+    return {
+        "name": "UPDATE_UNIT",
+        "data": {
+            "id": unit_id,
+            "ambientTemperature": 23,
+            "fan": 1,
+            "filter": False,
+            "operationMode": 2,
+            "operationStatus": 1,
+            "activeSetpoint": setpoint,
+            "swing": 0,
+        },
+    }
+
+
+class SubscribeUnitUpdatesTest(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        SingletonMeta._instances.pop(CoolAutomationClient, None)
+        self.client = CoolAutomationClient.__new__(CoolAutomationClient)
+        self.client.token = "test-token"
+        self.client.logger = MagicMock()
+        # _transform_message reads these dictionaries; stub them to identity.
+        self.client.fan_modes = MagicMock(get=lambda v: v)
+        self.client.operation_modes = MagicMock(get=lambda v: v)
+        self.client.operation_statuses = MagicMock(get=lambda v: v)
+        self.client.swing_modes = MagicMock(get=lambda v: v)
+        # subscribe_unit_updates accesses the REST client's ssl_context.
+        self.client.api_client = MagicMock()
+        self.client.api_client.rest_client = MagicMock()
+        self.client.api_client.rest_client.ssl_context = None
+
+    async def asyncTearDown(self):
+        SingletonMeta._instances.pop(CoolAutomationClient, None)
+
+    @staticmethod
+    def _patch_ws_connect(fake_wss, fake_session_holder=None):
+        """Return a patch that swaps aiohttp.ClientSession with a stub
+        whose ws_connect yields each `fake_wss` in order."""
+
+        class _Sess:
+            def __init__(self):
+                self._wss = list(fake_wss)
+                self.closed = False
+
+            def ws_connect(self, *a, **kw):
+                ws = self._wss.pop(0)
+
+                @asynccontextmanager
+                async def _cm():
+                    yield ws
+
+                return _cm()
+
+            async def close(self):
+                self.closed = True
+
+        sess = _Sess()
+        if fake_session_holder is not None:
+            fake_session_holder.append(sess)
+        return patch("aiohttp.ClientSession", return_value=sess)
+
+    async def test_yields_unit_update_per_update_unit_message(self):
+        fake = _FakeWs(
+            incoming=[
+                _make_text_msg(_make_unit_update_payload("unit-A", setpoint=22)),
+                _make_text_msg({"name": "UPDATE_SENSOR", "data": {}}),
+                _make_text_msg(_make_unit_update_payload("unit-B", setpoint=20)),
+            ],
+            terminate_with=asyncio.CancelledError(),
+        )
+        with self._patch_ws_connect([fake]):
+            events = []
+            try:
+                async for ev in self.client.subscribe_unit_updates():
+                    events.append(ev)
+            except asyncio.CancelledError:
+                pass
+
+        unit_updates = [e for e in events if isinstance(e, UnitUpdate)]
+        self.assertEqual(len(unit_updates), 2)
+        self.assertEqual(unit_updates[0].message.unit_id, "unit-A")
+        self.assertEqual(unit_updates[1].message.unit_id, "unit-B")
+        # Auth handshake sent on connect.
+        self.assertEqual(fake.sent[0]["type"], "authenticate")
+        self.assertEqual(fake.sent[0]["content"]["token"], "test-token")
+
+    async def test_emits_reconnected_after_drop(self):
+        ws1 = _FakeWs(
+            incoming=[_make_text_msg(_make_unit_update_payload("unit-A"))],
+            terminate_with=ConnectionResetError("drop"),
+        )
+        ws2 = _FakeWs(
+            incoming=[_make_text_msg(_make_unit_update_payload("unit-B"))],
+            terminate_with=asyncio.CancelledError(),
+        )
+
+        # Patch asyncio.sleep so backoff is instant in the test.
+        async def _instant_sleep(_):
+            return
+
+        with self._patch_ws_connect([ws1, ws2]), \
+             patch("asyncio.sleep", new=_instant_sleep):
+            events = []
+            try:
+                async for ev in self.client.subscribe_unit_updates():
+                    events.append(ev)
+                    if len(events) >= 3:
+                        raise asyncio.CancelledError()
+            except asyncio.CancelledError:
+                pass
+
+        self.assertIsInstance(events[0], UnitUpdate)
+        self.assertEqual(events[0].message.unit_id, "unit-A")
+        self.assertIsInstance(events[1], Reconnected)
+        self.assertIsInstance(events[2], UnitUpdate)
+        self.assertEqual(events[2].message.unit_id, "unit-B")
+
+    async def test_responds_to_app_level_ping_with_pong(self):
+        fake = _FakeWs(
+            incoming=[
+                _make_text_msg({"type": "ping"}),
+                _make_text_msg(_make_unit_update_payload("unit-A")),
+            ],
+            terminate_with=asyncio.CancelledError(),
+        )
+        with self._patch_ws_connect([fake]):
+            events = []
+            try:
+                async for ev in self.client.subscribe_unit_updates():
+                    events.append(ev)
+            except asyncio.CancelledError:
+                pass
+
+        # Ping was answered with pong (in addition to the auth message).
+        pongs = [m for m in fake.sent if m.get("type") == "pong"]
+        self.assertEqual(len(pongs), 1)
+        # Ping did not yield a WsEvent — only the UPDATE_UNIT did.
+        self.assertEqual(len(events), 1)
+        self.assertIsInstance(events[0], UnitUpdate)
+
+    async def test_cancellation_closes_session(self):
+        fake = _FakeWs(
+            incoming=[_make_text_msg(_make_unit_update_payload("unit-A"))],
+            terminate_with=asyncio.CancelledError(),
+        )
+        holder = []
+        with self._patch_ws_connect([fake], fake_session_holder=holder):
+            try:
+                async for _ in self.client.subscribe_unit_updates():
+                    raise asyncio.CancelledError()
+            except asyncio.CancelledError:
+                pass
+
+        self.assertTrue(holder[0].closed)
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run from `CoolControlOpenClient/`:
+
+```bash
+python3 -m unittest tests.test_subscribe_unit_updates -v
+```
+
+Expected: all four tests FAIL with `AttributeError: 'CoolAutomationClient' object has no attribute 'subscribe_unit_updates'`.
+
+- [ ] **Step 3: (Do not implement yet — proceed to Task 3 for the implementation.)**
+
+---
+
+## Task 3: Implement `subscribe_unit_updates`
+
+**Files:**
+- Modify: `CoolControlOpenClient/cool_open_client/cool_automation_client.py`
+
+- [ ] **Step 1: Add the method**
+
+Open `CoolControlOpenClient/cool_open_client/cool_automation_client.py`.
+
+1. Add to the imports near the top of the file (alongside the existing `import json`):
+
+```python
+import asyncio
+from typing import AsyncIterator
+
+import aiohttp
+
+from .ws_events import Reconnected, UnitUpdate, WsEvent
+```
+
+(`json`, `marshmallow`, `normalize_temperature_fields`, `UnitUpdateMessageSchema`, `_transform_message` are already in scope.)
+
+2. Add this method on `CoolAutomationClient`, immediately after `get_updated_controllable_units` (the bulk method we added in Step 1):
+
+```python
+    async def subscribe_unit_updates(self) -> AsyncIterator[WsEvent]:
+        """Subscribe to real-time unit state changes via WebSocket.
+
+        Yields a `UnitUpdate` for each server `UPDATE_UNIT` message and a
+        `Reconnected` event each time the underlying connection is
+        re-established following a drop. Reconnect uses exponential
+        backoff (1s, 2s, 4s, 8s, 16s, 32s, capped at 60s; reset to 1s on
+        successful authenticate). Iteration only ends when the caller
+        breaks out or the consuming task is cancelled.
+        """
+        session = aiohttp.ClientSession()
+        backoff = 1
+        first_connect = True
+        try:
+            while True:
+                try:
+                    async with session.ws_connect(
+                        self.SOCKET_URI,
+                        ssl=self.api_client.rest_client.ssl_context,
+                        heartbeat=30,
+                    ) as ws:
+                        await ws.send_json({
+                            "type": "authenticate",
+                            "content": {"token": self.token},
+                        })
+                        if not first_connect:
+                            yield Reconnected()
+                        first_connect = False
+                        backoff = 1
+
+                        async for raw in ws:
+                            if raw.type != aiohttp.WSMsgType.TEXT:
+                                continue
+                            try:
+                                msg = json.loads(raw.data)
+                            except (TypeError, ValueError):
+                                continue
+                            if msg.get("type") == "ping":
+                                await ws.send_json({"type": "pong"})
+                                continue
+                            if msg.get("name") != "UPDATE_UNIT":
+                                continue
+                            data = msg.get("data")
+                            if data is None:
+                                continue
+                            normalized = normalize_temperature_fields(data)
+                            update_message = UnitUpdateMessageSchema().load(
+                                normalized, unknown=marshmallow.EXCLUDE,
+                            )
+                            if update_message is None:
+                                continue
+                            update_message = self._transform_message(update_message)
+                            yield UnitUpdate(update_message)
+                except asyncio.CancelledError:
+                    raise
+                except Exception:
+                    self.logger.warning(
+                        "WS subscription error; reconnecting in %ds",
+                        backoff,
+                        exc_info=True,
+                    )
+                    await asyncio.sleep(backoff)
+                    backoff = min(backoff * 2, 60)
+        finally:
+            await session.close()
+```
+
+- [ ] **Step 2: Run the tests to verify they pass**
+
+Run from `CoolControlOpenClient/`:
+
+```bash
+python3 -m unittest tests.test_subscribe_unit_updates -v
+```
+
+Expected: all four tests PASS.
+
+- [ ] **Step 3: Run the full library test suite (mocked tests only)**
+
+Run from `CoolControlOpenClient/`:
+
+```bash
+python3 -m unittest tests.test_get_updated_controllable_units tests.test_ssl_context_passthrough tests.test_subscribe_unit_updates -v
+```
+
+Expected: all eleven tests PASS (3 + 4 + 4).
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd CoolControlOpenClient
+git add cool_open_client/cool_automation_client.py tests/test_subscribe_unit_updates.py
+git commit -m "feat: add async WS subscription (subscribe_unit_updates)
+
+Adds an aiohttp-native async generator that yields UnitUpdate per
+UPDATE_UNIT server message and Reconnected after each successful
+reconnect. Uses the existing SSL context (set by Home Assistant in
+Step 1.5) so the WS connection setup never blocks the event loop.
+Reuses normalize_temperature_fields + UnitUpdateMessageSchema +
+_transform_message so the message shape matches the HTTP bulk path.
+
+Replaces the thread-based path (kept here only briefly — removed in
+the next commit)."
+```
+
+---
+
+## Task 4: Remove the thread-based WebSocket implementation
+
+**Files:**
+- Modify: `CoolControlOpenClient/cool_open_client/cool_automation_client.py`
+- Modify: `CoolControlOpenClient/cool_open_client/unit.py`
+
+- [ ] **Step 1: Strip the legacy code from `cool_automation_client.py`**
+
+In `CoolControlOpenClient/cool_open_client/cool_automation_client.py`:
+
+Delete these elements in their entirety:
+- The `WebSocketThread` class (the whole class block).
+- The `import websocket` statement at the top of the file.
+- The `from websocket import (...)` import block (whatever names it brings in — usually `WebSocketApp`, `WebSocketConnectionClosedException`, `WebSocketException`).
+- `import threading` and `from threading import Thread` if no other code in the file uses them. (Search for `Thread\b` to confirm.) If they're used elsewhere in the file, leave them.
+- The `import gc` and `import time` imports if no other code in the file uses them. (Same check.)
+- The `self.socket = None` line in `__init__`.
+- The `self._registered_units: dict[str, Updatable] = {}` line in `__init__`.
+- The `self.ws_thread: Thread = None` line in `__init__`.
+- The `register_for_updates` method.
+- The `on_open_socket` method.
+- The `on_close_socket` method.
+- The `on_message_socket` method.
+- The `on_error_socket` method.
+- The `_handle_ping_pong` method.
+- The `_handle_ws_message` method.
+- The `open_socket` method (the whole method block, including the inner `try/except WebSocketException`).
+
+Keep all of:
+- `SOCKET_URI` constant — `subscribe_unit_updates` uses it.
+- `_transform_message` method.
+- `UnitUpdateMessage` dataclass + `UnitUpdateMessageSchema`.
+- Everything HTTP-related.
+- The new `subscribe_unit_updates` method.
+- `from .utils.updatable import Updatable` import — only if `Updatable` is still referenced after the strip (search for `Updatable\b`). If not, remove this import too.
+
+- [ ] **Step 2: Strip the dead callback machinery from `unit.py`**
+
+In `CoolControlOpenClient/cool_open_client/unit.py`:
+
+Delete these elements:
+- The `UnitCallback` protocol (if defined here).
+- The `unit_update_callback` method on the `UnitCallback` protocol.
+- The `regiter_callback` (sic) method on `HVACUnit`.
+- The `notify` method on `HVACUnit`.
+- The `_callbacks` list attribute initialized in `HVACUnit.__init__` (if present).
+
+Keep:
+- `_update_unit(self, message, with_callback=False)` — the integration's coordinator calls this directly.
+- `reset_update()`.
+- All other methods.
+
+If `HVACUnit._update_unit` previously called any callback when `with_callback=True`, the with_callback parameter and its branch become dead. Remove the parameter and the branch, leaving only the field-mutation logic. **Then update both callers in the library/integration to drop the kwarg:**
+
+- `cool_automation_client.py` — `subscribe_unit_updates` calls `_update_unit(update_message)` (no kwarg needed after this strip; the WS-side call site was just added in Task 3, update it here).
+- The integration's coordinator and `_ws_pump` will be updated in Task 8 / Task 9 to drop the kwarg.
+
+- [ ] **Step 3: Confirm imports are clean and tests pass**
+
+Run from `CoolControlOpenClient/`:
+
+```bash
+python3 -c "from cool_open_client.cool_automation_client import CoolAutomationClient; print('ok')"
+python3 -m unittest tests.test_get_updated_controllable_units tests.test_ssl_context_passthrough tests.test_subscribe_unit_updates -v
+```
+
+Expected: import succeeds; all eleven mocked tests still pass.
+
+- [ ] **Step 4: Delete the legacy live-API WS test**
+
+```bash
+cd CoolControlOpenClient
+rm tests/test_websocket.py
+```
+
+(The deleted test exercised `open_socket` against a live server and required a `token.txt`. Its replacement is `tests/test_subscribe_unit_updates.py` from Task 2.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd CoolControlOpenClient
+git add cool_open_client/cool_automation_client.py cool_open_client/unit.py tests/test_websocket.py
+git commit -m "refactor: remove thread-based WebSocket implementation
+
+Drops WebSocketThread, open_socket, all on_*_socket handlers,
+_handle_ping_pong, _handle_ws_message, register_for_updates,
+_registered_units, HVACUnit.regiter_callback, HVACUnit.notify,
+and the websocket-client import — superseded by the new
+subscribe_unit_updates async generator. The matching live-API
+test (tests/test_websocket.py) is deleted; the new async path
+is covered by tests/test_subscribe_unit_updates.py."
+```
+
+---
+
+## Task 5: Remove the `websocket-client` dependency
+
+**Files:**
+- Modify: `CoolControlOpenClient/setup.py`
+- Modify: `CoolControlOpenClient/requirements.txt`
+
+- [ ] **Step 1: Drop the dep from `setup.py`**
+
+In `CoolControlOpenClient/setup.py`, remove `"websocket-client"` (and its pinned version, if present) from the `install_requires` list. Save.
+
+- [ ] **Step 2: Drop the dep from `requirements.txt`**
+
+In `CoolControlOpenClient/requirements.txt`, delete the line that pins `websocket-client`. If there is no other dependency declared on that line, the line is removed entirely.
+
+- [ ] **Step 3: Verify imports still work without `websocket-client` installed**
+
+In a clean shell (or just trust the test run):
+
+```bash
+cd CoolControlOpenClient
+python3 -c "
+import sys
+# Pretend the package is gone so an accidental import fails loudly.
+sys.modules['websocket'] = None
+from cool_open_client.cool_automation_client import CoolAutomationClient
+print('ok — no websocket-client import')
+"
+```
+
+Expected: `ok — no websocket-client import`. Any `AttributeError` here means a stray reference survived the Task 4 strip — go back and find it.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd CoolControlOpenClient
+git add setup.py requirements.txt
+git commit -m "chore: drop websocket-client dependency"
+```
+
+---
+
+## Task 6: Bump library to 0.0.21, build wheel, tag
+
+**Files:**
+- Modify: `CoolControlOpenClient/setup.py`
+
+- [ ] **Step 1: Bump the version**
+
+In `CoolControlOpenClient/setup.py`, change `version="0.0.20",` to `version="0.0.21",`.
+
+- [ ] **Step 2: Build the distribution**
+
+Run from `CoolControlOpenClient/`:
+
+```bash
+python3 -m build --sdist --wheel --outdir dist/
+ls dist/cool_open_client-0.0.21*
+```
+
+Expected: `dist/cool_open_client-0.0.21-py3-none-any.whl` and `dist/cool_open_client-0.0.21.tar.gz` exist.
+
+- [ ] **Step 3: Commit and tag**
+
+```bash
+cd CoolControlOpenClient
+git add setup.py
+git commit -m "chore: bump cool-open-client to 0.0.21"
+git tag v0.0.21
+```
+
+- [ ] **Step 4: (Do not publish to PyPI yet.)** PyPI publish happens after the integration smoke test in Task 11.
+
+---
+
+## Task 7: Install the new wheel into the integration test venv
+
+**Files:** _none modified_
+
+The integration's `.venv-test` (created during Step 1) currently has `cool-open-client 0.0.20`. Install 0.0.21 so subsequent integration tests resolve against the new library.
+
+- [ ] **Step 1: Install**
+
+```bash
+/home/shayg/projects/HomeAssistant/cool-open-integration/.venv-test/bin/pip install -q --force-reinstall \
+  /home/shayg/projects/HomeAssistant/CoolControlOpenClient/dist/cool_open_client-0.0.21-py3-none-any.whl
+```
+
+Expected: silent success. Pydantic / urllib3 conflict warnings from `pip` are harmless (same as in Step 1.5 — the warnings don't affect our tests).
+
+- [ ] **Step 2: Verify**
+
+```bash
+/home/shayg/projects/HomeAssistant/cool-open-integration/.venv-test/bin/python -c "
+from cool_open_client.cool_automation_client import CoolAutomationClient
+from cool_open_client.ws_events import UnitUpdate, Reconnected
+print('have subscribe_unit_updates:', hasattr(CoolAutomationClient, 'subscribe_unit_updates'))
+print('have open_socket (should be False):', hasattr(CoolAutomationClient, 'open_socket'))
+"
+```
+
+Expected:
+```
+have subscribe_unit_updates: True
+have open_socket (should be False): False
+```
+
+---
+
+## Task 8: Integration test — WS pump routes UnitUpdate to coordinator
+
+**Files:**
+- Modify: `cool-open-integration/tests/test_coordinator.py`
+
+- [ ] **Step 1: Append the test**
+
+Append to `cool-open-integration/tests/test_coordinator.py`:
+
+```python
+from types import SimpleNamespace
+
+from custom_components.cool_open_integration import _ws_pump
+
+
+def _make_unit_update_event(unit_id: str):
+    """Stand-in for cool_open_client.ws_events.UnitUpdate; identity tested by isinstance against the real class."""
+    from cool_open_client.ws_events import UnitUpdate
+    msg = SimpleNamespace(unit_id=unit_id)
+    return UnitUpdate(msg)
+
+
+async def _aiter_from(events):
+    for ev in events:
+        yield ev
+
+
+@pytest.mark.asyncio
+async def test_ws_pump_routes_unit_update_to_in_memory_unit(hass):
+    units = [_make_unit("unit-A"), _make_unit("unit-B")]
+    client = MagicMock()
+    client.subscribe_unit_updates = MagicMock(
+        return_value=_aiter_from([_make_unit_update_event("unit-A")])
+    )
+
+    entry = MagicMock()
+    coordinator = CoolAutomationDataUpdateCoordinator(hass, entry, client, units)
+    coordinator.data = {u.id: u for u in units}
+    coordinator.async_set_updated_data = MagicMock()
+
+    await _ws_pump(coordinator)
+
+    # unit-A got the WS update; unit-B was untouched.
+    units[0]._update_unit.assert_called_once()
+    units[1]._update_unit.assert_not_called()
+    # Coordinator was notified.
+    coordinator.async_set_updated_data.assert_called_once()
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run from `cool-open-integration/`:
+
+```bash
+.venv-test/bin/pytest tests/test_coordinator.py::test_ws_pump_routes_unit_update_to_in_memory_unit -v
+```
+
+Expected: FAIL with `ImportError: cannot import name '_ws_pump' from 'custom_components.cool_open_integration'`. We add `_ws_pump` in Task 9.
+
+---
+
+## Task 9: Integration test — `Reconnected` triggers a refresh
+
+**Files:**
+- Modify: `cool-open-integration/tests/test_coordinator.py`
+
+- [ ] **Step 1: Append the test**
+
+```python
+@pytest.mark.asyncio
+async def test_ws_pump_reconnected_triggers_refresh(hass):
+    from cool_open_client.ws_events import Reconnected
+
+    units = [_make_unit("unit-A")]
+    client = MagicMock()
+    client.subscribe_unit_updates = MagicMock(return_value=_aiter_from([Reconnected()]))
+
+    entry = MagicMock()
+    coordinator = CoolAutomationDataUpdateCoordinator(hass, entry, client, units)
+    coordinator.data = {u.id: u for u in units}
+    coordinator.async_request_refresh = AsyncMock()
+
+    await _ws_pump(coordinator)
+
+    coordinator.async_request_refresh.assert_awaited_once()
+    # No UnitUpdate, so no _update_unit call.
+    units[0]._update_unit.assert_not_called()
+```
+
+- [ ] **Step 2: Run all coordinator tests** to confirm only the two new ones fail:
+
+```bash
+.venv-test/bin/pytest tests/test_coordinator.py -v
+```
+
+Expected: 3 PASS (Step 1's existing tests), 2 FAIL (the new tests, since `_ws_pump` doesn't exist yet).
+
+---
+
+## Task 10: Integration test — unknown unit_id is silently ignored
+
+**Files:**
+- Modify: `cool-open-integration/tests/test_coordinator.py`
+
+- [ ] **Step 1: Append the test**
+
+```python
+@pytest.mark.asyncio
+async def test_ws_pump_unknown_unit_id_ignored(hass):
+    units = [_make_unit("unit-A")]
+    client = MagicMock()
+    client.subscribe_unit_updates = MagicMock(
+        return_value=_aiter_from([_make_unit_update_event("unit-NEW")])
+    )
+
+    entry = MagicMock()
+    coordinator = CoolAutomationDataUpdateCoordinator(hass, entry, client, units)
+    coordinator.data = {u.id: u for u in units}
+    coordinator.async_set_updated_data = MagicMock()
+
+    # Must not raise.
+    await _ws_pump(coordinator)
+
+    units[0]._update_unit.assert_not_called()
+    coordinator.async_set_updated_data.assert_not_called()
+```
+
+- [ ] **Step 2: Run all coordinator tests** to confirm now three of them fail:
+
+```bash
+.venv-test/bin/pytest tests/test_coordinator.py -v
+```
+
+Expected: 3 PASS, 3 FAIL.
+
+- [ ] **Step 3: Commit the three new failing tests**
+
+```bash
+cd cool-open-integration
+git add tests/test_coordinator.py
+git commit -m "test: add WS pump contracts (failing — pump implemented next)"
+```
+
+---
+
+## Task 11: Implement `_ws_pump` and rewire `async_setup_entry`
+
+**Files:**
+- Modify: `cool-open-integration/custom_components/cool_open_integration/__init__.py`
+
+- [ ] **Step 1: Add imports and the pump**
+
+In `cool-open-integration/custom_components/cool_open_integration/__init__.py`:
+
+1. Add to the imports block (after the existing `from cool_open_client.cool_automation_client import ...`):
+
+```python
+import asyncio
+
+from cool_open_client.ws_events import Reconnected, UnitUpdate
+```
+
+2. Add this module-level coroutine, just below the existing imports / above `async_setup_entry`:
+
+```python
+async def _ws_pump(coordinator: "CoolAutomationDataUpdateCoordinator") -> None:
+    """Forever-loop consumer of the library's WS event stream.
+
+    Mutates in-memory `HVACUnit` instances per `UnitUpdate` and triggers a
+    bulk reconcile on each `Reconnected`. Cancellation propagates so HA
+    can stop us cleanly during entry unload.
+    """
+    client = coordinator.client
+    units_by_id = {u.id: u for u in coordinator.units}
+
+    try:
+        async for event in client.subscribe_unit_updates():
+            if isinstance(event, UnitUpdate):
+                unit = units_by_id.get(event.message.unit_id)
+                if unit is None:
+                    continue
+                unit._update_unit(event.message)
+                coordinator.async_set_updated_data(coordinator.data)
+            elif isinstance(event, Reconnected):
+                await coordinator.async_request_refresh()
+    except asyncio.CancelledError:
+        raise
+    except Exception:
+        _LOGGER.exception(
+            "WS pump terminated unexpectedly; entry will rely on the "
+            "5-minute reconciliation poll until reload",
+        )
+```
+
+3. Inside `async_setup_entry`, find the line `hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator` and insert immediately after it (before the `async_forward_entry_setups` call):
+
+```python
+    entry.async_create_background_task(
+        hass,
+        _ws_pump(coordinator),
+        name=f"{DOMAIN}_ws_pump",
+    )
+```
+
+- [ ] **Step 2: Run the test suite**
+
+```bash
+cd cool-open-integration
+.venv-test/bin/pytest tests/test_coordinator.py -v
+```
+
+Expected: all six tests PASS (3 Step-1 tests + 3 new WS tests).
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd cool-open-integration
+git add custom_components/cool_open_integration/__init__.py
+git commit -m "feat: drive coordinator from WS pump
+
+Spawn a background task per config entry that consumes
+client.subscribe_unit_updates(). UnitUpdate mutates the in-memory
+HVACUnit and notifies the coordinator immediately; Reconnected
+triggers an immediate bulk reconcile. Coordinator lifecycle owns
+the task — cancelled automatically on entry unload."
+```
+
+---
+
+## Task 12: Switch coordinator to 5-minute reconciliation cadence
+
+**Files:**
+- Modify: `cool-open-integration/custom_components/cool_open_integration/const.py`
+- Modify: `cool-open-integration/custom_components/cool_open_integration/coordinator.py`
+
+- [ ] **Step 1: Replace `POLL_INTERVAL` with `RECONCILE_INTERVAL` in `const.py`**
+
+Open `cool-open-integration/custom_components/cool_open_integration/const.py`. Find the line `POLL_INTERVAL = 30` and replace the entire line with:
+
+```python
+RECONCILE_INTERVAL_MINUTES = 5
+```
+
+(Keep the constant on its own line; other constants in the file are unchanged.)
+
+- [ ] **Step 2: Use it in the coordinator**
+
+Open `cool-open-integration/custom_components/cool_open_integration/coordinator.py`. Make these edits:
+
+1. Replace this import:
+
+```python
+from .const import DOMAIN, POLL_INTERVAL
+```
+
+with:
+
+```python
+from .const import DOMAIN, RECONCILE_INTERVAL_MINUTES
+```
+
+2. Replace this line in `__init__`:
+
+```python
+super().__init__(hass, _LOGGER, name=DOMAIN, update_interval=timedelta(seconds=POLL_INTERVAL))
+```
+
+with:
+
+```python
+super().__init__(
+    hass,
+    _LOGGER,
+    name=DOMAIN,
+    update_interval=timedelta(minutes=RECONCILE_INTERVAL_MINUTES),
+)
+```
+
+- [ ] **Step 3: Drop the now-removed `with_callback` kwarg from the coordinator's update call**
+
+The `with_callback` parameter on `HVACUnit._update_unit` was removed in Task 4 (the legacy callback machinery is gone). The Step 1 coordinator code still passes `with_callback=False`. Fix that call site.
+
+In `cool-open-integration/custom_components/cool_open_integration/coordinator.py`, find this line inside `_async_update_data`:
+
+```python
+unit._update_unit(message, with_callback=False)
+```
+
+Replace with:
+
+```python
+unit._update_unit(message)
+```
+
+- [ ] **Step 4: Re-run the coordinator tests**
+
+```bash
+cd cool-open-integration
+.venv-test/bin/pytest tests/test_coordinator.py -v
+```
+
+Expected: all six tests PASS. (None of the tests depend on the specific interval, so the change is invisible to them.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd cool-open-integration
+git add custom_components/cool_open_integration/const.py custom_components/cool_open_integration/coordinator.py
+git commit -m "feat: drop reconciliation poll cadence to 5 minutes
+
+With the WS pump driving live state, the bulk poll is now a drift-
+correction safety net rather than the primary update mechanism.
+288 req/day per site instead of ~2,880."
+```
+
+---
+
+## Task 13: Bump integration manifest
+
+**Files:**
+- Modify: `cool-open-integration/custom_components/cool_open_integration/manifest.json`
+
+- [ ] **Step 1: Edit `manifest.json`**
+
+Open `cool-open-integration/custom_components/cool_open_integration/manifest.json` and apply three changes:
+
+1. `"iot_class": "cloud_polling"` → `"iot_class": "cloud_push"`
+2. `"cool-open-client==0.0.20"` → `"cool-open-client==0.0.21"`
+3. `"version": "0.0.16"` → `"version": "0.0.17"`
+
+The file should look like:
+
+```json
+{
+  "domain": "cool_open_integration",
+  "name": "CoolAutomation Cloud Open Integration",
+  "codeowners": ["@ShayGus"],
+  "config_flow": true,
+  "dependencies": [],
+  "documentation": "https://github.com/ShayGus/cool-open-integration/wiki",
+  "homekit": {},
+  "iot_class": "cloud_push",
+  "issue_tracker": "https://github.com/ShayGus/cool-open-integration/issues",
+  "requirements": ["cool-open-client==0.0.21"],
+  "ssdp": [],
+  "version": "0.0.17",
+  "zeroconf": []
+}
+```
+
+- [ ] **Step 2: Confirm tests still pass**
+
+```bash
+cd cool-open-integration
+.venv-test/bin/pytest tests/test_coordinator.py -v
+```
+
+Expected: 6/6 PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd cool-open-integration
+git add custom_components/cool_open_integration/manifest.json
+git commit -m "chore: pin cool-open-client==0.0.21, version 0.0.17, iot_class cloud_push"
+```
+
+---
+
+## Task 14: Manual smoke test on the dev container
+
+This is a human verification step — automated tests cannot prove the WS pump talks to CoolAutomation's real server.
+
+- [ ] **Step 1: Install the 0.0.21 wheel into the devcontainer**
+
+Inside the running `vsc-core` devcontainer:
+
+```bash
+pip install --force-reinstall /coc/dist/cool_open_client-0.0.21-py3-none-any.whl
+```
+
+- [ ] **Step 2: Restart HA and enable DEBUG logging**
+
+In `/workspaces/core/config/configuration.yaml`, ensure:
+
+```yaml
+logger:
+  default: warning
+  logs:
+    custom_components.cool_open_integration: debug
+    cool_open_client: debug
+```
+
+Restart HA.
+
+- [ ] **Step 3: Verify the WS pump connected**
+
+Wait ~10 seconds, then:
+
+```bash
+grep -E "subscribe_unit_updates|WS subscription|authenticate|cool_open_integration_ws_pump" \
+  /workspaces/core/config/home-assistant.log | tail -20
+```
+
+Expected: an authentication message went out shortly after setup; the pump task is running. No `Detected blocking call` warnings.
+
+- [ ] **Step 4: Verify push updates arrive**
+
+Change a unit's setpoint or mode physically (wall remote) or via CoolAutomation's own UI. Within ~2 seconds, the HA UI should reflect the change. In the log:
+
+```bash
+tail -f /workspaces/core/config/home-assistant.log | grep -Ei 'UPDATE_UNIT|update_message|_ws_pump'
+```
+
+Expected: an `UPDATE_UNIT` message landed in the pump, `_update_unit` was called, the entity refreshed.
+
+- [ ] **Step 5: Verify the reconciliation poll runs at the new cadence**
+
+```bash
+grep -E "get_updated_controllable_units|units_get" /workspaces/core/config/home-assistant.log | tail -10
+```
+
+Expected: bulk fetches roughly every 5 minutes — not every 30 seconds.
+
+- [ ] **Step 6: Verify reconnect behaviour**
+
+Disconnect the container's network briefly (`docker network disconnect bridge <container>` then reconnect), or restart your router. Watch the log:
+
+Expected: a "WS subscription error; reconnecting in 1s" warning, then a successful reconnect, then a `Reconnected`-triggered bulk reconcile fires (an extra `units_get` immediately after the reconnect).
+
+- [ ] **Step 7: Verify entity controls still work**
+
+In the HA UI, change a setpoint / mode from the entity card. Confirm:
+1. The change is accepted (HTTP call still works).
+2. The new state shows up within ~2 seconds (echoed back via the WS).
+3. No errors logged.
+
+---
+
+## Task 15: Ship the library — push branch + tag + publish to PyPI
+
+This is the customer-facing release step.
+
+- [ ] **Step 1: Push branch and tag**
+
+```bash
+cd CoolControlOpenClient
+git push origin <feature-branch>
+git push origin v0.0.21
+```
+
+- [ ] **Step 2: Open the library PR**
+
+```bash
+gh pr create --base master --head <feature-branch> --title "Push updates via async WS subscription (0.0.21)" --body "$(cat <<'EOF'
+## Summary
+
+- New async generator `CoolAutomationClient.subscribe_unit_updates()` yields `UnitUpdate` events from the CoolAutomation WebSocket and `Reconnected` events after transparent reconnects.
+- Implementation is aiohttp-native and reuses the SSL context Home Assistant passes in (set up in Step 1.5), so the WS connection setup never blocks the event loop.
+- Removes the legacy thread-based WS implementation (`WebSocketThread`, `open_socket`, `on_*_socket`, `_handle_ws_message`, `register_for_updates`, the `websocket-client` dependency).
+
+## Breaking changes
+
+Pre-1.0 library. Callers using `open_socket` / `register_for_updates` / `HVACUnit.regiter_callback` will need to switch to `subscribe_unit_updates`. The only known consumer (`cool-open-integration`) is updated in tandem.
+
+## Tests
+
+Four new mocked tests covering: UPDATE_UNIT yield path, Reconnected emission, app-level ping → pong, cancellation closes session.
+EOF
+)"
+```
+
+- [ ] **Step 3: Merge** the PR via the GitHub UI (or `gh pr merge`).
+
+- [ ] **Step 4: Publish to PyPI**
+
+Inside the project root (where `script/publish.sh` lives):
+
+```bash
+ls dist/                                                # confirm only 0.0.21 artifacts
+rm dist/cool_open_client-0.0.20*                        # purge previously-published version
+script/publish.sh
+```
+
+Confirm visible at <https://pypi.org/project/cool-open-client/0.0.21/>.
+
+---
+
+## Task 16: Ship the integration — push branch + PR + tag + HACS rollout
+
+- [ ] **Step 1: Push branch**
+
+```bash
+cd cool-open-integration
+git push origin <feature-branch>
+```
+
+- [ ] **Step 2: Open the integration PR**
+
+```bash
+gh pr create --base main --head <feature-branch> --title "Push-driven coordinator via WS subscription (0.0.17)" --body "$(cat <<'EOF'
+## Summary
+
+- Coordinator is now WS-driven: a background task consumes `cool_open_client.CoolAutomationClient.subscribe_unit_updates()` and pushes state changes into the entity layer in near-real-time.
+- The Step 1 bulk poll is kept as a 5-minute reconciliation safety net.
+- `iot_class` flipped to `cloud_push`. Manifest pinned to `cool-open-client==0.0.21`.
+
+## Effect
+
+- Per-site traffic drops further: ~288 reconciliation HTTP requests/day + 1 long-lived WS connection. (Was: ~2,880 req/day after Step 1; ~250K/day before.)
+- Unit state changes from wall remotes appear in HA within ~2 seconds instead of up to 30.
+
+## Test plan
+
+- [ ] `pytest tests/` — 6/6 (3 Step 1 + 3 new WS pump tests).
+- [ ] Manual smoke test on real HA confirms WS connects, UPDATE_UNIT messages flow, reconnect triggers immediate reconcile, controls still work.
+EOF
+)"
+```
+
+- [ ] **Step 3: Merge** the PR.
+
+- [ ] **Step 4: Tag and push the release**
+
+```bash
+cd cool-open-integration
+git checkout main && git pull --ff-only origin main
+git tag 0.0.17
+git push origin 0.0.17
+```
+
+HACS picks up the new tag and rolls 0.0.17 out to subscribed users over the next 24-48 hours.
+
+---
+
+## Done criteria
+
+- [ ] `cool-open-client==0.0.21` is on PyPI; includes `subscribe_unit_updates` and no `websocket-client` dependency.
+- [ ] `cool-open-integration==0.0.17` is tagged on `main`; `manifest.json` pins the new client and declares `iot_class: cloud_push`.
+- [ ] All eleven library mocked tests and all six integration tests pass under `pytest` / `unittest`.
+- [ ] Manual smoke test on real HA confirms: (1) WS connects without `Detected blocking call` warnings, (2) UPDATE_UNIT pushes arrive in < 2 s, (3) reconciliation poll cadence dropped to 5 min, (4) reconnect triggers immediate bulk reconcile, (5) entity controls still work via HTTP.
+- [ ] Adam (CoolAutomation) confirms the new traffic shape after rollout.

--- a/docs/superpowers/specs/2026-05-20-cool-open-api-traffic-reduction-design.md
+++ b/docs/superpowers/specs/2026-05-20-cool-open-api-traffic-reduction-design.md
@@ -1,0 +1,356 @@
+# Cool Open API Traffic Reduction — Design
+
+**Date:** 2026-05-20
+**Status:** Step 1 approved; Step 2 design pending
+
+## Context
+
+CoolAutomation (Adam Itshar, VP R&D, 2026-05-17) reported a major spike in
+"unauthorized" / over-quota API traffic traced to the `cool-open-integration`
+Home Assistant custom integration. One commercial site (~87-unit hotel) is
+generating ~250K requests/day. CoolAutomation has indicated they may restrict
+access if usage isn't reduced.
+
+Root cause: `cool-open-integration` polls the per-unit endpoint
+(`GET /units/{id}`) once every 30 seconds for *each* unit. With N units this
+issues N requests per cycle, ~2,880 × N requests/day per HA install.
+
+Source of the issue:
+- `cool-open-integration/custom_components/cool_open_integration/const.py:11` — `POLL_INTERVAL = 30`
+- `cool-open-integration/custom_components/cool_open_integration/coordinator.py:33-40` — `_async_update_data` loops `await unit.refresh()` per unit
+- `CoolControlOpenClient/cool_open_client/unit.py:127-129` — `HVACUnit.refresh` → `client.get_updated_controllable_unit(self._id)` (per-unit HTTP)
+
+`cool-open-client` already exposes a bulk endpoint (`get_controllable_units()`)
+and a thread-based websocket (`ws_thread`, `on_message_socket`), but neither is
+used by the coordinator. The websocket cannot be safely consumed by HA today
+because the underlying transport is `websocket-client` running in a `Thread` —
+not asyncio-native; bridging via `async_add_executor_job` risks blocking HA's
+event loop. (See memory `project-cool-open-integration-ws-decision`.)
+
+## Plan
+
+Two phases:
+
+1. **Step 1 — Initial fix release.** Replace per-unit polling with a single
+   bulk call per cycle. Solves Adam's traffic problem (~99% reduction) without
+   touching the websocket. Ships fast.
+2. **Step 2 — Long-term solution.** Refactor `cool-open-client` to expose an
+   aiohttp-native async websocket subscription; flip the integration to
+   `iot_class: cloud_push` and drive the coordinator via
+   `async_set_updated_data`. Polling drops to a low-frequency sanity sync.
+   (Design TBD — separate brainstorming round after Step 1 ships.)
+
+This document specifies **Step 1**. Step 2 will be specified separately once
+Step 1 is in users' hands and we can observe real-world behaviour.
+
+---
+
+## Step 1 — Initial fix release
+
+### Goal
+
+Reduce per-cycle HTTP request count from O(N) to O(1) for any site with N
+units. Preserve current 30-second update cadence, entity identity, and
+mutation semantics.
+
+### Non-goals
+
+- WebSocket adoption (Step 2).
+- Changing `iot_class` (stays `cloud_polling`).
+- Removing the per-unit `unit.refresh()` method from `cool-open-client` (kept
+  for backward compatibility; just not called by the coordinator anymore).
+- Renaming intentional library typos (`set_opration_mode`,
+  `UNAUTHORIZES_ERROR_CODE`) — breaking changes on a published library.
+- Lint/format/type-check configuration.
+- Broad test coverage push beyond what's needed to lock the new path.
+
+### Architecture
+
+Two coordinated repos:
+
+```
+┌────────────────────────────────────────────────────────────────┐
+│  cool-open-client  (PyPI: cool-open-client, 0.0.18 → 0.0.19)   │
+│                                                                │
+│  Add:                                                          │
+│    CoolAutomationClient.get_updated_controllable_units()       │
+│      → dict[str, UnitUpdateMessage]                            │
+│                                                                │
+│  Reuses existing:                                              │
+│    - UnitsApi.units_get()  (the bulk endpoint)                 │
+│    - _transform_message() (same translation per unit)          │
+│                                                                │
+│  Unchanged:                                                    │
+│    - get_updated_controllable_unit() (per-unit, deprecated     │
+│      but kept)                                                 │
+│    - HVACUnit.refresh()  (still calls the per-unit path)       │
+│    - WebSocket plumbing (Step 2)                               │
+└────────────────────────────────────────────────────────────────┘
+                              ▲
+                              │ requirements pin: cool-open-client==0.0.19
+                              │
+┌────────────────────────────────────────────────────────────────┐
+│  cool-open-integration  (manifest.json: 0.0.14 → 0.0.15)       │
+│                                                                │
+│  Change:                                                       │
+│    coordinator._async_update_data:                             │
+│      one bulk call → distribute UnitUpdateMessage to each      │
+│      HVACUnit via _update_unit(msg, with_callback=False)       │
+│                                                                │
+│  Unchanged:                                                    │
+│    - POLL_INTERVAL = 30  (cadence preserved)                   │
+│    - HVACUnit instance identity (entities hold references)     │
+│    - Setup flow, config flow, climate entity behaviour         │
+└────────────────────────────────────────────────────────────────┘
+```
+
+### Components — `cool-open-client`
+
+#### New method: `CoolAutomationClient.get_updated_controllable_units`
+
+```python
+@with_exception
+async def get_updated_controllable_units(self) -> dict[str, UnitUpdateMessage]:
+    """
+    Bulk equivalent of get_updated_controllable_unit. Issues one HTTP
+    request and returns a mapping of unit_id → transformed update message.
+    """
+    api = UnitsApi(api_client=self.api_client)
+    response: UnitsResponse = await api.units_get(
+        x_access_token=self.token,
+        origin=self.ORIGIN,
+        referer=self.REFERER,
+    )
+
+    updates: dict[str, UnitUpdateMessage] = {}
+    payload = _extract_units_mapping(response.data)  # module-level helper
+
+    for unit_id, raw in payload.items():
+        raw_dict = _ensure_dict(raw)
+        # Skip non-controllable types (matches HVACUnitsFactory filter
+        # exactly — filter runs on the raw dict, before model construction)
+        if isinstance(raw_dict, dict) and raw_dict.get("type") not in (None, 1):
+            continue
+        try:
+            unit = dict_to_model(UnitResponseData, raw)
+        except TypeError:
+            continue
+
+        message = UnitUpdateMessage(
+            ambient_temperature=round_temperature_value(unit.ambient_temperature),
+            fan_mode=unit.active_fan_mode,
+            operation_mode=unit.active_operation_mode,
+            setpoint=round_temperature_value(unit.active_setpoint),
+            swing=unit.active_swing_mode,
+            operation_status=unit.active_operation_status,
+            filter=unit.filter,
+            unit_id=unit.id or unit_id,
+        )
+        updates[message.unit_id] = self._transform_message(message)
+
+    return updates
+```
+
+The unit-payload extraction (`_extract_units_mapping`) is lifted from
+`HVACUnitsFactory._extract_mapping` / `_ensure_dict` and made a module-level
+helper so both the factory (setup-time) and the new client method
+(update-time) share the same defensive parsing.
+
+#### Backward compatibility
+
+- `get_updated_controllable_unit(unit_id)` stays. Callers outside this repo
+  (if any) keep working.
+- `HVACUnit.refresh()` stays. It still calls the per-unit endpoint. The
+  integration's coordinator simply stops calling it.
+
+#### Versioning
+
+`cool-open-client`: `0.0.18 → 0.0.19`. Patch-level; additive change only.
+
+### Components — `cool-open-integration`
+
+#### Rewrite: `CoolAutomationDataUpdateCoordinator._async_update_data`
+
+Current:
+
+```python
+async def _async_update_data(self):
+    try:
+        data = {}
+        for unit in self.units:
+            await unit.refresh()
+            data[unit.id] = unit
+            unit.reset_update()
+    except OSError as error:
+        raise UpdateFailed from error
+    return data
+```
+
+New:
+
+```python
+async def _async_update_data(self):
+    try:
+        updates = await self._client.get_updated_controllable_units()
+    except OSError as error:
+        raise UpdateFailed from error
+    except Exception as error:
+        # Auth or transport failure: surface as UpdateFailed so HA keeps
+        # the last known good data instead of blanking entities.
+        raise UpdateFailed(f"Bulk unit update failed: {error}") from error
+
+    data: dict[str, HVACUnit] = {}
+    for unit in self.units:
+        message = updates.get(unit.id)
+        if message is not None:
+            unit._update_unit(message, with_callback=False)
+        # If a unit is missing from the bulk response, keep its last-known
+        # state rather than dropping it — matches today's behaviour when a
+        # transient per-unit fetch fails.
+        data[unit.id] = unit
+        unit.reset_update()
+    return data
+```
+
+Key properties:
+- **One HTTP request per cycle** regardless of N.
+- **Entity identity preserved.** Existing `HVACUnit` instances are mutated
+  in place. Climate entities and the coordinator both reference units by
+  the same `unit_id` keys, so no cross-reference invalidation.
+- **`reset_update()` retained** — keeps the existing `_update_pending`
+  debounce behaviour after entity-driven writes.
+- **Missing-unit handling** — a unit absent from the bulk response is left
+  alone, not deleted. Matches existing tolerance for transient failures.
+
+#### Pin bump
+
+`cool-open-integration/custom_components/cool_open_integration/manifest.json`:
+
+```diff
+-  "requirements": ["cool-open-client==0.0.18"],
++  "requirements": ["cool-open-client==0.0.19"],
+-  "version": "0.0.14",
++  "version": "0.0.15",
+```
+
+`iot_class` stays `cloud_polling`. (Step 2 flips it.)
+
+### Data flow
+
+```
+HA scheduler fires every 30s
+        │
+        ▼
+coordinator._async_update_data()
+        │
+        ▼
+client.get_updated_controllable_units()  ── ONE HTTPS GET ──►  CoolAutomation API
+        │                                                            │
+        │                          ◄─────  UnitsResponse  ───────────┘
+        ▼
+dict[str, UnitUpdateMessage]
+        │
+        ▼
+for unit in self.units:
+    unit._update_unit(updates[unit.id], with_callback=False)
+        │
+        ▼
+DataUpdateCoordinator notifies CoordinatorEntity subscribers
+        │
+        ▼
+Climate entities re-render
+```
+
+### Error handling
+
+| Failure | Behaviour |
+|---|---|
+| `OSError` (network) | `UpdateFailed`, HA shows entity unavailability after threshold |
+| `aiohttp.ClientError` / HTTP 5xx | Wrapped → `UpdateFailed` |
+| HTTP 401 / token expired | Wrapped → `UpdateFailed`. (Token-refresh logic is out of scope; same behaviour as today.) |
+| Bulk response missing a unit_id | That unit keeps last-known state; no exception |
+| Bulk response contains unknown unit_ids | Ignored (we only mutate units we know about) |
+| Pydantic / schema mismatch on a single unit | That unit skipped; loop continues for others. Log at WARNING. |
+
+The integration explicitly does **not** fall back to per-unit polling on
+bulk failure. Falling back would re-introduce the traffic problem any time
+the bulk endpoint has a transient issue — and bulk failures are typically
+auth / availability problems that per-unit calls would also hit.
+
+### Testing
+
+Establish a minimal `pytest-homeassistant-custom-component` scaffold and
+two coordinator tests. Goal: lock in the new contract; not exhaustive
+coverage.
+
+**Test 1 — request fan-out:** Mock `client.get_updated_controllable_units`
+to return a fixture of 100 unit updates. Assert that after one
+`_async_update_data()` cycle, `client.get_updated_controllable_unit` was
+called **zero** times and `client.get_updated_controllable_units` was
+called **once**.
+
+**Test 2 — entity identity preserved:** Start with N units, run a refresh,
+assert `coordinator.data[unit_id] is original_unit` for every id (same
+object, mutated in place). Then assert one mutated field (e.g. setpoint)
+reflects the bulk response.
+
+**Test 3 — missing unit tolerance:** Start with N units; bulk response
+omits one. Assert that unit remains in `coordinator.data` with its prior
+state and `UpdateFailed` is *not* raised.
+
+Tests live in `cool-open-integration/tests/test_coordinator.py`. Library
+already has a test directory (`CoolControlOpenClient/tests/`) — add one
+test there exercising the new method against a recorded fixture (no live
+API), patterned after the existing async test files.
+
+### Release plan
+
+1. Land library change in `CoolControlOpenClient` main; tag `0.0.19`;
+   publish to PyPI.
+2. Open integration PR with coordinator change, requirement bump, version
+   bump, and tests.
+3. Manual smoke test on a real account: confirm one HTTP call per 30s
+   cycle in DEBUG logs.
+4. Merge integration PR; tag `0.0.15`.
+5. Notify Adam with the version and expected traffic shape (~2,880
+   req/day per site, regardless of unit count).
+
+### Risk register
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| Bulk endpoint schema drift breaks parsing | Low | Defensive `_extract_units_mapping` already tolerates pydantic-strict mismatches; per-unit skip on parse error |
+| Adam's team ships their own PR with a conflicting shape | Medium | If their PR arrives first and is correct, merge theirs instead. Spec describes the end state, not authorship. |
+| HVACUnit.notify() callbacks fire unexpectedly via `_update_unit` | Low | Call site passes `with_callback=False`, matching current `refresh()` |
+| Bulk endpoint slower than per-unit at very small N (<5 units) | Very low | At N=5, bulk = 1 req, per-unit = 5 req — bulk is still ≤ per-unit. No regression scenario. |
+| Existing users with token expiry get worse error UX | Low | Same surface as today; deferred to Step 2 |
+
+### Success criteria
+
+- Traffic from a 100-unit installation: ≤ 3,000 requests/day (currently ~288,000).
+- No regression in climate entity behaviour observable from HA UI.
+- All three new tests pass.
+- Adam confirms reduced traffic from the hotel customer within one week of
+  release.
+
+---
+
+## Step 2 — Long-term solution
+
+**Status:** Shipped 2026-05-21 as `cool-open-client 0.0.21` (PyPI) and
+`cool-open-integration 0.0.17` (HACS).
+
+**Design spec:** `docs/superpowers/specs/2026-05-20-cool-open-websocket-push-design.md`
+
+**Implementation plan:** `docs/superpowers/plans/2026-05-20-cool-open-websocket-push-step2.md`
+
+**Outcome:** Replaced the 30-second bulk poll with a push-driven coordinator
+backed by `CoolAutomationClient.subscribe_unit_updates()` — an aiohttp-native
+async iterator yielding `UnitUpdate` events per server `UPDATE_UNIT` and
+`Reconnected` events after each transparent reconnect. The bulk poll is
+retained as a 5-minute drift-correction safety net. The legacy thread-based
+WebSocket implementation and the `websocket-client` PyPI dependency were
+removed entirely. `iot_class` is now `cloud_push`.
+
+**Net traffic per site after Step 2:** ~288 reconciliation HTTP requests/day
+plus 1 long-lived WebSocket connection — another ~90% drop on top of Step 1.

--- a/docs/superpowers/specs/2026-05-20-cool-open-websocket-push-design.md
+++ b/docs/superpowers/specs/2026-05-20-cool-open-websocket-push-design.md
@@ -1,0 +1,456 @@
+# Cool Open WebSocket Push Updates — Step 2 Design
+
+**Date:** 2026-05-20
+**Status:** Approved scope; pending implementation plan
+**Predecessor:** `2026-05-20-cool-open-api-traffic-reduction-design.md` (Step 1 + Step 1.5 — bulk endpoint + SSL context, shipped as `cool-open-client 0.0.20` / `cool-open-integration 0.0.16`)
+
+## Context
+
+Step 1 dropped per-cycle API traffic from O(N) to O(1) by switching the
+coordinator's 30-second poll to a single bulk request. This solved
+CoolAutomation's immediate concern (the 87-unit hotel customer went from
+~250K req/day to ~2,880).
+
+Step 2 finishes the job by moving the integration from polling to **push
+updates over the existing CoolAutomation WebSocket**. The library already
+has working WS plumbing (now bug-fixed by community PR #2 in 0.0.21-pending),
+but uses the thread-based `websocket-client` package — not safe for the HA
+event loop. (See memory `project-cool-open-integration-ws-decision`.) This
+spec replaces it with an `aiohttp`-native async path and rewires the
+integration's coordinator to be push-driven, with a low-frequency
+reconciliation poll as a safety net.
+
+Net traffic per site after Step 2: 1 long-lived WS connection plus ~288
+reconciliation HTTP requests per day, regardless of unit count.
+
+## Goals
+
+- Convert `cool-open-integration` to `iot_class: cloud_push`.
+- Replace the integration's 30-second bulk poll with a 5-minute
+  reconciliation poll plus real-time WS updates.
+- Remove the thread-based WS implementation from `cool-open-client` and
+  drop the `websocket-client` PyPI dependency.
+- Preserve all behaviour Step 1 locked in: `HVACUnit` instance identity,
+  in-place mutation, missing-unit tolerance.
+
+## Non-goals
+
+- Driving entity *commands* over WS (still HTTP via existing client methods).
+- Surfacing non-`UPDATE_UNIT` WS messages (sensors, power meters, events).
+- Multi-account / multi-entry shared WS connection.
+- A user-facing config option to disable WS. (Easy to add later if a need
+  emerges; not adding speculatively.)
+- Changes to the bulk `_async_update_data` body — same one-line bulk call
+  shipped in Step 1.
+
+## Architecture
+
+```
+                ┌──────────────────────────────────────────────┐
+                │  cool-open-client  (new 0.0.21)              │
+                │                                              │
+                │  CoolAutomationClient.subscribe_unit_updates()│
+                │    → AsyncIterator[WsEvent]                  │
+                │                                              │
+                │    WsEvent = UnitUpdate(message) |           │
+                │              Reconnected()                   │
+                │                                              │
+                │  Internal aiohttp.ClientSession.ws_connect   │
+                │  with exponential backoff (1,2,4,…,60s)      │
+                │  Filters to UPDATE_UNIT only                 │
+                │  Reuses _transform_message, UnitUpdateMessage│
+                │                                              │
+                │  REMOVED: open_socket, WebSocketThread,      │
+                │   on_open/message/error/close, ping/pong,    │
+                │   HVACUnit.regiter_callback,                 │
+                │   `websocket-client` PyPI dep                │
+                └──────────────────────────────────────────────┘
+                                  ▲
+                                  │ async iterator
+                                  │
+                ┌──────────────────────────────────────────────┐
+                │  cool-open-integration  (new 0.0.17)         │
+                │                                              │
+                │  __init__.py async_setup_entry:              │
+                │    after coordinator first refresh,          │
+                │    entry.async_create_background_task(       │
+                │        _ws_pump(coordinator))                │
+                │                                              │
+                │  _ws_pump:                                   │
+                │    async for ev in client.subscribe_         │
+                │                     unit_updates():          │
+                │      if UnitUpdate:                          │
+                │        unit._update_unit(ev.message,         │
+                │                          with_callback=False)│
+                │        coordinator.async_set_updated_data(…) │
+                │      elif Reconnected:                       │
+                │        await coordinator.async_request_      │
+                │                         refresh()            │
+                │                                              │
+                │  coordinator update_interval = 5 minutes     │
+                │  (was 30 s); _async_update_data unchanged    │
+                │                                              │
+                │  manifest.json: iot_class → cloud_push       │
+                └──────────────────────────────────────────────┘
+```
+
+Two complementary update channels feed one `DataUpdateCoordinator`:
+
+1. **WS pump (primary).** A background task tied to the config entry's
+   lifecycle, reading the library's async iterator forever. Each
+   `UnitUpdate` mutates the corresponding in-memory `HVACUnit` and pushes a
+   coordinator update.
+2. **Reconciliation (safety net).** `update_interval = 5 minutes` runs the
+   same one-bulk-call `_async_update_data` we wrote in Step 1. The WS pump
+   also triggers an immediate `async_request_refresh()` on every
+   `Reconnected` event so we catch up without waiting up to 5 minutes.
+
+## Library component (`cool-open-client`)
+
+### New public API
+
+```python
+# cool_open_client/ws_events.py  (new module)
+from dataclasses import dataclass
+from typing import Union
+from .cool_automation_client import UnitUpdateMessage
+
+
+@dataclass(frozen=True)
+class UnitUpdate:
+    """A real-time state change for a single HVAC unit."""
+    message: UnitUpdateMessage
+
+
+@dataclass(frozen=True)
+class Reconnected:
+    """The WS connection dropped and was restored.
+
+    Consumers should reconcile state since one or more UnitUpdate
+    messages may have been missed during the gap.
+    """
+    pass
+
+
+WsEvent = Union[UnitUpdate, Reconnected]
+```
+
+```python
+# new method on CoolAutomationClient
+async def subscribe_unit_updates(self) -> AsyncIterator[WsEvent]:
+    """Subscribe to real-time unit state changes via WebSocket.
+
+    Yields:
+        UnitUpdate: for each `UPDATE_UNIT` server message.
+        Reconnected: after the underlying connection is re-established
+            following a drop.
+
+    Reconnect is handled internally with exponential backoff (1s, 2s,
+    4s, 8s, 16s, 32s, capped at 60s; reset to 1s on successful
+    authenticate). Iteration only ends when the caller breaks out or
+    the consuming task is cancelled.
+    """
+```
+
+### Internal implementation
+
+A new module `cool_open_client/ws_subscription.py` holds the WS loop
+(~120 lines). `CoolAutomationClient.subscribe_unit_updates` delegates to
+it. Pseudocode:
+
+```python
+async def _run(self) -> AsyncIterator[WsEvent]:
+    backoff = 1
+    first = True
+    while True:
+        try:
+            async with self._session.ws_connect(
+                SOCKET_URI,
+                ssl=self._ssl_context,
+                heartbeat=30,
+            ) as ws:
+                await ws.send_json({
+                    "type": "authenticate",
+                    "content": {"token": self._token},
+                })
+                # Auth response is implicit — first failure surfaces below.
+                if not first:
+                    yield Reconnected()
+                first = False
+                backoff = 1
+
+                async for raw in ws:
+                    if raw.type != aiohttp.WSMsgType.TEXT:
+                        continue
+                    msg = json.loads(raw.data)
+                    if msg.get("type") == "ping":
+                        await ws.send_json({"type": "pong"})
+                        continue
+                    if msg.get("name") != "UPDATE_UNIT":
+                        continue
+                    update_message = self._build_message(msg.get("data") or {})
+                    if update_message is not None:
+                        yield UnitUpdate(update_message)
+
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            self._logger.warning("WS pump error; reconnecting in %ds", backoff,
+                                 exc_info=True)
+            await asyncio.sleep(backoff)
+            backoff = min(backoff * 2, 60)
+```
+
+Key properties:
+- **SSL context reuse.** Passes `ssl=self.api_client.rest_client.ssl_context`
+  — the same Step 1.5 context already constructed off the event loop.
+- **Heartbeat.** `heartbeat=30` lets aiohttp send WS-level pings and surface
+  dead connections quickly rather than waiting for a TCP timeout.
+- **App-level ping/pong.** The CoolAutomation server emits `{"type":"ping"}`
+  messages too; we reply with `pong` per the existing protocol (preserved
+  from the deleted thread-based code).
+- **Filter.** Drops anything where `name != "UPDATE_UNIT"`. (PR #2's fix —
+  inherited via the master merge that lands in 0.0.21.)
+- **Cancellation-safe.** `CancelledError` propagates; `async with` closes
+  the WS session cleanly.
+
+### Removed surface (breaking)
+
+| File / symbol | Action |
+|---|---|
+| `cool_automation_client.py` — `open_socket`, `on_open_socket`, `on_message_socket`, `on_error_socket`, `on_close_socket`, `_handle_ping_pong`, `_handle_ws_message`, `ws_thread` attr | Delete |
+| `cool_automation_client.py` — `WebSocketThread` class | Delete |
+| `cool_automation_client.py` — `import websocket`, `from websocket import …` | Delete |
+| `unit.py` — `HVACUnit.regiter_callback` (sic), `unit_update_callback` protocol, `notify` plumbing | Delete |
+| `cool_automation_client.py` — `_registered_units` dict + related methods | Delete |
+| `setup.py` / `requirements.txt` — `websocket-client` | Remove |
+| `tests/test_websocket.py` (existing live-API test, currently skipped without `token.txt`) | Delete or rewrite to exercise the new aiohttp path |
+
+`aiohttp` is already a transitive dep via the REST client; no new package.
+
+### Kept and reused
+
+- `UnitUpdateMessage` dataclass — single source of truth for the message
+  shape, consumed by both the HTTP bulk path (Step 1) and the WS path
+  (Step 2).
+- `_transform_message` — same numeric-id-to-string translation for both
+  paths. Factored if needed so `subscribe_unit_updates` can call it
+  without reaching into the bulk endpoint logic.
+- `HVACUnit._update_unit(message, with_callback=False)` — integration calls
+  it directly per `UnitUpdate` event, exactly as Step 1's coordinator does
+  per bulk response. With_callback=False is preserved.
+
+## Integration component (`cool-open-integration`)
+
+### Setup flow
+
+```python
+# __init__.py — key changes (only the new bits shown)
+
+from cool_open_client.ws_events import UnitUpdate, Reconnected
+
+async def async_setup_entry(hass, entry):
+    # ... (unchanged: SSL context, token, client, factory, initial units,
+    #     coordinator construction, async_config_entry_first_refresh) ...
+
+    entry.async_create_background_task(
+        hass,
+        _ws_pump(coordinator),
+        name=f"{DOMAIN}_ws_pump",
+    )
+
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    return True
+
+
+async def _ws_pump(coordinator):
+    """Long-running consumer of the library's WS event stream."""
+    client = coordinator.client
+    units_by_id = {u.id: u for u in coordinator.units}
+
+    try:
+        async for event in client.subscribe_unit_updates():
+            if isinstance(event, UnitUpdate):
+                unit = units_by_id.get(event.message.unit_id)
+                if unit is None:
+                    # Unit appeared after setup; will be picked up by the
+                    # next reconciliation poll.
+                    continue
+                unit._update_unit(event.message, with_callback=False)
+                coordinator.async_set_updated_data(coordinator.data)
+            elif isinstance(event, Reconnected):
+                # WS came back; some messages may have been missed during
+                # the gap. Trigger one immediate bulk reconcile.
+                await coordinator.async_request_refresh()
+    except asyncio.CancelledError:
+        raise
+    except Exception:
+        _LOGGER.exception(
+            "WS pump terminated unexpectedly; entry will rely on the "
+            "5-minute reconciliation poll until reload",
+        )
+```
+
+### Coordinator change
+
+```python
+# coordinator.py
+RECONCILE_INTERVAL = timedelta(minutes=5)
+
+class CoolAutomationDataUpdateCoordinator(DataUpdateCoordinator):
+    def __init__(self, hass, entry, client, units):
+        # ...
+        super().__init__(
+            hass, _LOGGER, name=DOMAIN,
+            update_interval=RECONCILE_INTERVAL,
+        )
+
+    async def _async_update_data(self):
+        # ↳ unchanged from Step 1 — one bulk call, distribute to in-memory units
+        ...
+```
+
+`POLL_INTERVAL` in `const.py` becomes dead. Remove it.
+
+### Manifest
+
+```diff
+-  "iot_class": "cloud_polling",
++  "iot_class": "cloud_push",
+-  "requirements": ["cool-open-client==0.0.20"],
++  "requirements": ["cool-open-client==0.0.21"],
+-  "version": "0.0.16",
++  "version": "0.0.17",
+```
+
+### Unload behaviour
+
+No integration-side changes needed. `entry.async_create_background_task`
+registers the task with the entry; HA cancels it automatically during
+`async_unload_entry`. The library catches `CancelledError`, closes the
+aiohttp WS session, and re-raises — clean shutdown.
+
+## Data flow per event
+
+```
+CoolAutomation server pushes {"name":"UPDATE_UNIT", "data":{…}}
+        │
+        ▼
+aiohttp.ClientWebSocketResponse  (inside subscribe_unit_updates)
+        │
+        ▼
+filter: name == "UPDATE_UNIT"
+        │
+        ▼
+build UnitUpdateMessage from data; _transform_message
+        │
+        ▼
+yield UnitUpdate(message)
+        │  ← async iterator boundary
+        ▼
+_ws_pump receives UnitUpdate
+        │
+        ▼
+units_by_id[message.unit_id]._update_unit(message, with_callback=False)
+        │
+        ▼
+coordinator.async_set_updated_data(coordinator.data)
+        │
+        ▼
+CoordinatorEntity subscribers (climate entities) re-render
+```
+
+Reconnect path:
+
+```
+WS drops  → exception inside subscribe_unit_updates  → log + backoff sleep
+        → reconnect, authenticate                    → yield Reconnected()
+        │  ← async iterator boundary
+        ▼
+_ws_pump receives Reconnected
+        ▼
+await coordinator.async_request_refresh()
+        ▼
+_async_update_data runs (bulk poll), distributes fresh state to all units
+        ▼
+coordinator notifies subscribers
+```
+
+## Failure modes
+
+| Scenario | Behaviour |
+|---|---|
+| WS fails to connect on first try (or repeatedly) | Library retries with exponential backoff. Integration state still arrives via the 5-minute reconciliation poll. UI works, just less snappy. |
+| Network blip mid-stream | Library reconnects. On success: `Reconnected` event → immediate reconcile. Typical drift window < 10 s. |
+| WS pump task crashes with unexpected exception | `_LOGGER.exception` once with traceback; coordinator continues running the reconciliation poll alone. User can reload entry to restart the WS pump. |
+| Unit added or removed mid-session | Reconciliation poll discovers the change next cycle (≤ 5 min). WS messages for an unknown `unit_id` are silently skipped. |
+| Token expires mid-stream | Library raises `InvalidTokenException` on the failing reconnect attempt; integration's existing reauth logic in `async_setup_entry` kicks in on next reload. (Token refresh during a live WS session is out of scope here — same surface as today.) |
+| Race: bulk-poll reconcile mutates a unit at the exact moment a WS message does | Both paths call `unit._update_unit` (idempotent on identical payloads) and then push coordinator updates. Worst case: one redundant entity state push. |
+
+## Testing
+
+### Library (mocked — no live API)
+
+1. **`test_subscribe_yields_unit_update_per_update_unit_message`** — patch
+   `aiohttp.ClientSession.ws_connect` to a fake context manager yielding a
+   sequence of WS messages including one `UPDATE_UNIT` and one
+   `UPDATE_SENSOR`. Assert the iterator yields exactly one `UnitUpdate`
+   with the correct payload.
+2. **`test_subscribe_emits_reconnected_after_drop`** — fake WS raises after
+   the first message; assert iterator yields the first `UnitUpdate`,
+   then `Reconnected`, then resumes yielding from the second connection.
+3. **`test_subscribe_responds_to_app_level_ping`** — fake WS pushes
+   `{"type":"ping"}`; assert the integration replies with `{"type":"pong"}`
+   via `ws.send_json`.
+4. **`test_subscribe_cancellation_closes_session`** — start iteration,
+   cancel the consuming task, assert the WS session was closed.
+
+Co-located with existing Step 1 tests under `CoolControlOpenClient/tests/`.
+
+### Integration
+
+1. **`test_ws_unit_update_mutates_coordinator_data`** — feed `_ws_pump`
+   a stub async iterator emitting one `UnitUpdate`; assert the
+   corresponding `HVACUnit._update_unit` was called and
+   `async_set_updated_data` fired.
+2. **`test_ws_reconnect_triggers_refresh`** — emit a `Reconnected` event;
+   assert `coordinator.async_request_refresh()` was called.
+3. **`test_ws_pump_unknown_unit_id_ignored`** — emit a `UnitUpdate` for a
+   `unit_id` not in the integration's units list; assert no exception and
+   no mutation.
+
+Existing Step 1 coordinator tests (3) continue to pass unchanged.
+
+## Release sequencing
+
+1. **Library first.** Cut `cool-open-client 0.0.21` from `master` (already
+   has community PR #2's fixes); publish to PyPI. End users still on
+   integration 0.0.16 are unaffected — their pin `cool-open-client==0.0.20`
+   continues to resolve.
+2. **Integration next.** PR onto `main`, merge, tag `0.0.17`. HACS rolls it
+   out. Pip resolves `cool-open-client==0.0.21` on each HA at first
+   restart.
+
+Rollback path is symmetric: HACS downgrade reverts the pin; the WS code
+becomes dead code on the previous integration version.
+
+## Risks worth tracking
+
+| Risk | Mitigation |
+|---|---|
+| CoolAutomation has undocumented WS rate limits (e.g., one connection per token) | Pending Adam's reply. If multi-instance HA setups break, throttle reconnects further or add a "WS disabled" config option in a follow-up. |
+| Reconciliation poll racing with a WS update during the same moment | Both call paths mutate `HVACUnit` in place. Worst case: one redundant entity state push. Idempotent. |
+| HA versions without `entry.async_create_background_task` (added 2023.8) | Current HA installs comfortably satisfy this. Document min HA version in `manifest.json` if needed. |
+| `aiohttp.ClientSession.ws_connect` ssl param compatibility with HA's bundled aiohttp | Same SSL context used successfully in Step 1.5 for REST; WS uses the same transport. Low risk. |
+| Token-refresh-during-live-WS | Out of scope; same surface as today. Open as a follow-up if user complaints emerge. |
+
+## Success criteria
+
+- Integration declares `iot_class: cloud_push`.
+- Steady-state HTTP traffic per site: ~288 reconciliation requests/day +
+  1 long-lived WS connection.
+- Real-world: a unit changed via wall remote appears in the HA UI within
+  seconds, not 30 s.
+- All Step 1 coordinator tests + new Step 2 tests pass.
+- Adam confirms (or doesn't complain about) the new traffic shape and
+  WS connection count.


### PR DESCRIPTION
Adds the design and plan docs that drove the traffic-reduction and push-update work shipped in versions 0.0.15, 0.0.16, and 0.0.17.

\`docs/superpowers/specs/\`
- \`2026-05-20-cool-open-api-traffic-reduction-design.md\` — Step 1 (bulk endpoint) and Step 1.5 (HA SSL context) design.
- \`2026-05-20-cool-open-websocket-push-design.md\` — Step 2 (WebSocket push + 5-min reconciliation) design.

\`docs/superpowers/plans/\`
- \`2026-05-20-cool-open-api-traffic-reduction-step1.md\` — task-level plan for Step 1 + 1.5.
- \`2026-05-20-cool-open-websocket-push-step2.md\` — task-level plan for Step 2.

Docs-only change. No code, no behaviour change.