### PR TITLE
Fix token refresh overwriting entire config entry data

### DIFF
--- a/custom_components/cool_open_integration/__init__.py
+++ b/custom_components/cool_open_integration/__init__.py
@@ -83,7 +83,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 username, password, ssl_context=ssl_ctx
             )
             hass.config_entries.async_update_entry(
-                entry, data={"username": username, "password": password, "token": token}
+                entry, data={**entry.data, "token": token}
             )
             client = await CoolAutomationClient.create(token=token, ssl_context=ssl_ctx)
         except Exception as error:


### PR DESCRIPTION
`async_update_entry` was called with a fresh dict literal containing only `username`, `password`, and `token`. Any other keys stored by the config flow were silently discarded on every token refresh.

Replace the literal with `{**entry.data, "token": token}` so only the expired token is updated and all other fields are preserved.

**Changes:**
- `__init__.py` — one-line fix to `async_update_entry` call in the token refresh path