### PR TITLE
Guard climate entity properties against None mode values

### DIFF
--- a/custom_components/cool_open_integration/climate.py
+++ b/custom_components/cool_open_integration/climate.py
@@ -158,14 +158,16 @@ class CoolAutomationUnitEntity(
     def hvac_mode(self) -> HVACMode:
         """Return hvac operation."""
         if self.unit.is_on:
-            return OPEN_CLIENT_TO_HA_MODES[self.unit.operation_mode]
+            return OPEN_CLIENT_TO_HA_MODES.get(self.unit.operation_mode, HVACMode.OFF)
         return HVACMode.OFF
 
     @property
     def hvac_modes(self) -> list[HVACMode]:
         """Return the list of available hvac operation modes."""
         hvac_modes = [
-            OPEN_CLIENT_TO_HA_MODES[mode] for mode in self.unit.operation_modes
+            OPEN_CLIENT_TO_HA_MODES[mode]
+            for mode in self.unit.operation_modes
+            if mode in OPEN_CLIENT_TO_HA_MODES
         ]
         hvac_modes.append(HVACMode.OFF)
         return hvac_modes if hvac_modes else [HVACMode.OFF]
@@ -188,7 +190,7 @@ class CoolAutomationUnitEntity(
     @property
     def fan_mode(self) -> str | None:
         """Return the fan setting."""
-        return self.unit.fan_mode.capitalize()
+        return self.unit.fan_mode.capitalize() if self.unit.fan_mode else None
 
     @property
     def fan_modes(self) -> list[str] | None:
@@ -199,7 +201,7 @@ class CoolAutomationUnitEntity(
     @property
     def swing_mode(self) -> str | None:
         """Return the fan setting."""
-        return self.unit.swing_mode.capitalize()
+        return self.unit.swing_mode.capitalize() if self.unit.swing_mode else None
 
     @property
     def swing_modes(self) -> list[str] | None:


### PR DESCRIPTION
`fan_mode` and `swing_mode` called `.capitalize()` unconditionally, crashing with `AttributeError` when the API returns `None` for a unit that has no active mode set. `hvac_mode` used a bare dict lookup that raises `KeyError` for any mode value not present in `OPEN_CLIENT_TO_HA_MODES`. `hvac_modes` had the same `KeyError` risk for unmapped supported modes.

All four properties now handle `None` / unmapped values gracefully rather than raising at entity update time.

**Changes:**
- `climate.py` — `fan_mode`: add `None` guard before `.capitalize()`
- `climate.py` — `swing_mode`: add `None` guard before `.capitalize()`
- `climate.py` — `hvac_mode`: use `.get()` with `HVACMode.OFF` fallback
- `climate.py` — `hvac_modes`: filter out unmapped modes instead of raising