### PR TITLE
Fix duplicate entity IDs by using unit ID instead of name

### DIFF
--- a/custom_components/cool_open_integration/climate.py
+++ b/custom_components/cool_open_integration/climate.py
@@ -99,7 +99,7 @@ class CoolAutomationUnitEntity(
 
         self._client = coordinator.client
         self.unit: HVACUnit = coordinator.data[unit_id]
-        self._attr_unique_id = self.unit.name
+        self._attr_unique_id = self.unit.id
         self._attr_temperature_unit = CELSIUS
         self._attr_supported_features = self.get_supported_features()
         self._attr_precision = self.get_precision()


### PR DESCRIPTION
`_attr_unique_id` was set to the unit's display name, which is not guaranteed to be unique. Any account with two units sharing the same name (e.g. "Living Room" in different sites) would have all but the first silently dropped by HA with "already exists — ignoring" warnings.

Use `unit.id` (the platform-assigned ObjectId) which is guaranteed unique across the entire CoolAutomation platform.

**Changes:**
- `climate.py` — `_attr_unique_id = self.unit.name` → `_attr_unique_id = self.unit.id`