### PR TITLE
Fix case-sensitive fan mode validation rejecting UI-provided values

### DIFF
--- a/custom_components/cool_open_integration/climate.py
+++ b/custom_components/cool_open_integration/climate.py
@@ -273,17 +273,22 @@ class CoolAutomationUnitEntity(
         if not fan_mode or not fan_mode.strip():
             raise ValueError("Fan mode cannot be empty")
 
-        # Use exact mode strings from API - no case conversion
+        # HA is served capitalized mode names (see fan_modes property), so map
+        # the incoming value back to the API's mode string case-insensitively.
         available_modes = list(self.unit.fan_modes)
+        api_mode = next(
+            (mode for mode in available_modes if mode.casefold() == fan_mode.casefold()),
+            None,
+        )
 
-        if fan_mode not in available_modes:
+        if api_mode is None:
             raise ValueError(
-                f"Fan mode {fan_mode} is not valid. Valid fan modes are: {', '.join(available_modes)}"
+                f"Fan mode {fan_mode} is not valid. Valid fan modes are: "
+                f"{', '.join(mode.capitalize() for mode in available_modes)}"
             )
 
         try:
-            # Pass the exact mode string as provided by the API
-            await self.unit.set_fan_mode(fan_mode)
+            await self.unit.set_fan_mode(api_mode)
         except Exception as error:
             _LOGGER.error("Failed to set fan mode: %s", error)
             raise HomeAssistantError(f"Fan mode setting failed: {error}") from error

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -1,0 +1,62 @@
+"""Tests for the climate entity fan mode handling."""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.cool_open_integration.climate import CoolAutomationUnitEntity
+
+API_FAN_MODES = ["LOW", "MEDIUM", "HIGH", "AUTO", "TOP"]
+
+
+def _make_entity() -> MagicMock:
+    entity = MagicMock(spec=CoolAutomationUnitEntity)
+    entity.unit = MagicMock()
+    entity.unit.fan_modes = list(API_FAN_MODES)
+    entity.unit.set_fan_mode = AsyncMock()
+    entity.coordinator = MagicMock()
+    entity.coordinator.async_request_refresh = AsyncMock()
+    return entity
+
+
+async def _set_fan_mode(entity: MagicMock, fan_mode: str) -> None:
+    with patch(
+        "custom_components.cool_open_integration.climate.asyncio.sleep",
+        new=AsyncMock(),
+    ):
+        await CoolAutomationUnitEntity.async_set_fan_mode(entity, fan_mode)
+
+
+def test_fan_modes_property_capitalizes() -> None:
+    """The fan_modes property serves capitalized names to HA."""
+    entity = _make_entity()
+    assert CoolAutomationUnitEntity.fan_modes.fget(entity) == [
+        "Low",
+        "Medium",
+        "High",
+        "Auto",
+        "Top",
+    ]
+
+
+async def test_set_fan_mode_accepts_capitalized_mode() -> None:
+    """A mode as served by the fan_modes property round-trips to the API string."""
+    entity = _make_entity()
+    await _set_fan_mode(entity, "Low")
+    entity.unit.set_fan_mode.assert_awaited_once_with("LOW")
+
+
+async def test_set_fan_mode_accepts_api_cased_mode() -> None:
+    """The raw API casing keeps working too."""
+    entity = _make_entity()
+    await _set_fan_mode(entity, "MEDIUM")
+    entity.unit.set_fan_mode.assert_awaited_once_with("MEDIUM")
+
+
+async def test_set_fan_mode_rejects_unknown_mode() -> None:
+    """An unknown mode raises and lists the HA-facing mode names."""
+    entity = _make_entity()
+    with pytest.raises(ValueError, match="Low, Medium, High, Auto, Top"):
+        await _set_fan_mode(entity, "Turbo")
+    entity.unit.set_fan_mode.assert_not_awaited()


### PR DESCRIPTION
## Problem

Changing the fan speed from the Home Assistant UI always fails with:

```
Failed to perform the action climate/set_fan_mode. Fan mode Low is not valid. Valid fan modes are: LOW, MEDIUM, HIGH, AUTO, TOP
```

The `fan_modes` property serves capitalized mode names to HA (`'Low'`, `'Medium'`, ...), but `async_set_fan_mode` validated the incoming value against the raw API strings (`'LOW'`, `'MEDIUM'`, ...) — so the entity rejected the very values it advertised.

Fixes #14

## Fix

- Map the incoming fan mode back to the API mode string case-insensitively (`casefold()` comparison), and pass the API-cased value to `set_fan_mode`. Both `'Low'` and `'LOW'` are accepted, so existing automations keep working.
- The validation error now lists the capitalized names the UI actually shows.

## Tests

Added `tests/test_climate.py` with regression tests covering:
- `fan_modes` property serves capitalized names
- capitalized mode round-trips to the API string
- raw API casing still accepted
- unknown mode raises with the HA-facing mode names

```
10 passed in 6.21s  (4 new + 6 existing coordinator tests)
```

## Note

Swing mode has the inverse asymmetry (`swing_mode` property capitalizes the current value, `swing_modes` list is raw) — left out of scope here, happy to follow up separately.