### PR TITLE
chore: release 0.0.19

### DIFF
--- a/custom_components/cool_open_integration/manifest.json
+++ b/custom_components/cool_open_integration/manifest.json
@@ -14,6 +14,6 @@
     "cool-open-client==0.0.22"
   ],
   "ssdp": [],
-  "version": "0.0.18",
+  "version": "0.0.19",
   "zeroconf": []
 }


### PR DESCRIPTION
Release bump to 0.0.19.

Ships the fan-mode (#14) and swing-mode fixes merged in #16. The version bump was pushed to that branch just after #16 merged, so it never landed on `main`; this PR lands it.

- `manifest.json` version 0.0.18 -> 0.0.19 (single-line diff, CRLF preserved)
- `cool-open-client` pin unchanged (0.0.22)

After merge: tag `0.0.19`, push tag, then `gh release create 0.0.19` (HACS needs the GitHub Release).