### PR TITLE
chore: clean hacs.json + release 0.0.20

### DIFF
--- a/custom_components/cool_open_integration/manifest.json
+++ b/custom_components/cool_open_integration/manifest.json
@@ -14,6 +14,6 @@
     "cool-open-client==0.0.22"
   ],
   "ssdp": [],
-  "version": "0.0.19",
+  "version": "0.0.20",
   "zeroconf": []
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,8 +1,6 @@
 {
     "name": "Cool Open Integration",
     "content_in_root": false,
-    "filename": "my_super_awesome_thing.js",
-    "country": ["NO", "SE", "DK"],
     "hide_default_branch": true,
     "render_readme": true
-  }
+}


### PR DESCRIPTION
Removes uncleaned HACS template fields from `hacs.json`:
- `filename: my_super_awesome_thing.js` — plugin-only placeholder, ignored for an integration
- `country: [NO, SE, DK]` — restricted HACS store visibility to those countries only

Bumps version to 0.0.20 so the corrected metadata ships (hacs.json changes only take effect via a release).