### PR TITLE
fix: migrate climate unique_id (name -> stable unit id) + restore customizations

### DIFF
--- a/custom_components/cool_open_integration/__init__.py
+++ b/custom_components/cool_open_integration/__init__.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 import asyncio
 import logging
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.util.ssl import client_context
+from homeassistant.const import Platform
+from homeassistant.helpers import entity_registry as er
 
 from cool_open_client.hvac_units_factory import HVACUnitsFactory
 from cool_open_client.cool_automation_client import (
@@ -51,6 +53,81 @@ async def _ws_pump(coordinator: "CoolAutomationDataUpdateCoordinator") -> None:
             "WS pump terminated unexpectedly; entry will rely on the "
             "5-minute reconciliation poll until reload",
         )
+
+
+@callback
+def _async_migrate_unique_ids(
+    hass: HomeAssistant, entry: ConfigEntry, units: list
+) -> None:
+    """Migrate climate entity unique_ids from unit name to stable unit id.
+
+    Releases <= 0.0.18 keyed climate entities by ``unit.name``; 0.0.19 switched
+    to ``unit.id`` without a migration, which orphaned users' customized
+    entities (names/areas) and created fresh id-keyed ones. Re-key each original
+    name-based registry entry onto ``unit.id`` to restore those customizations.
+
+    An id-keyed entry already auto-created by 0.0.19/0.0.20 is removed first so
+    the re-key does not collide. Units that share a ``name`` are skipped: the
+    single name-based entry is ambiguous, so re-keying could attach the wrong
+    unit's customizations. All lookups are scoped to this config entry, since
+    ``async_get_entity_id`` matches globally across accounts.
+    """
+    registry = er.async_get(hass)
+
+    name_counts: dict[str, int] = {}
+    for unit in units:
+        if unit.name:
+            name_counts[unit.name] = name_counts.get(unit.name, 0) + 1
+
+    for unit in units:
+        old_unique_id = unit.name
+        new_unique_id = unit.id
+        if not old_unique_id or old_unique_id == new_unique_id:
+            continue
+
+        old_entity_id = registry.async_get_entity_id(
+            Platform.CLIMATE, DOMAIN, old_unique_id
+        )
+        if old_entity_id is None:
+            continue  # nothing keyed by name: already migrated or fresh install
+
+        old_entry = registry.async_get(old_entity_id)
+        if old_entry is None or old_entry.config_entry_id != entry.entry_id:
+            continue  # belongs to a different config entry / account
+
+        if name_counts.get(old_unique_id, 0) > 1:
+            _LOGGER.warning(
+                "Skipping unique_id migration for duplicate unit name %r; "
+                "re-key would be ambiguous. Rename the units to disambiguate",
+                old_unique_id,
+            )
+            continue
+
+        new_entity_id = registry.async_get_entity_id(
+            Platform.CLIMATE, DOMAIN, new_unique_id
+        )
+        if new_entity_id is not None and new_entity_id != old_entity_id:
+            new_entry = registry.async_get(new_entity_id)
+            if new_entry is None or new_entry.config_entry_id != entry.entry_id:
+                _LOGGER.warning(
+                    "Cannot migrate %r -> %s: target unique_id is already used by "
+                    "another config entry; skipping",
+                    old_unique_id,
+                    new_unique_id,
+                )
+                continue
+            _LOGGER.debug(
+                "Removing auto-created climate entity %s so %r can migrate to %s",
+                new_entity_id,
+                old_unique_id,
+                new_unique_id,
+            )
+            registry.async_remove(new_entity_id)
+
+        _LOGGER.info(
+            "Migrating climate unique_id %r -> %s", old_unique_id, new_unique_id
+        )
+        registry.async_update_entity(old_entity_id, new_unique_id=new_unique_id)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -116,6 +193,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         _ws_pump(coordinator),
         name=f"{DOMAIN}_ws_pump",
     )
+    _async_migrate_unique_ids(hass, entry, units)
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     # hass.config_entries.async_setup_platforms(entry, PLATFORMS)
     return True

--- a/custom_components/cool_open_integration/manifest.json
+++ b/custom_components/cool_open_integration/manifest.json
@@ -14,6 +14,6 @@
     "cool-open-client==0.0.22"
   ],
   "ssdp": [],
-  "version": "0.0.20",
+  "version": "0.0.21",
   "zeroconf": []
 }

--- a/tests/test_init_migration.py
+++ b/tests/test_init_migration.py
@@ -1,0 +1,225 @@
+"""Tests for ``_async_migrate_unique_ids`` (entity-registry re-key migration).
+
+Releases <= 0.0.18 keyed climate entities by ``unit.name``; 0.0.19 switched to
+``unit.id`` without migrating, orphaning users' customized entities. The
+migration re-keys each original name-based registry entry onto ``unit.id`` so
+customizations (name/area) survive, while carefully skipping ambiguous or
+foreign-owned entries.
+
+These tests drive a real entity registry (``er.async_get(hass)``) and seed it
+with ``MockConfigEntry``-owned climate entities, then assert the observable
+post-migration registry state through the public lookup API.
+"""
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+
+from homeassistant.helpers import area_registry as ar, entity_registry as er
+
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.cool_open_integration import _async_migrate_unique_ids
+from custom_components.cool_open_integration.const import DOMAIN
+
+CLIMATE = "climate"
+
+
+def _unit(name, unit_id):
+    """Stub for an HVAC unit: ``.name`` is the old unique_id, ``.id`` the new."""
+    return SimpleNamespace(name=name, id=unit_id)
+
+
+def _entry(hass):
+    """A config entry for this integration, registered with hass."""
+    entry = MockConfigEntry(domain=DOMAIN)
+    entry.add_to_hass(hass)
+    return entry
+
+
+async def test_old_only_rekey_preserves_customizations(hass):
+    """A lone name-keyed entity is re-keyed onto unit.id, keeping id/name/area."""
+    registry = er.async_get(hass)
+    entry = _entry(hass)
+    area = ar.async_get(hass).async_create("Study Area")
+
+    old = registry.async_get_or_create(
+        CLIMATE, DOMAIN, "Study", config_entry=entry, suggested_object_id="study"
+    )
+    registry.async_update_entity(old.entity_id, name="Study A/C", area_id=area.id)
+
+    _async_migrate_unique_ids(hass, entry, [_unit("Study", "unit-abc")])
+
+    # Name-based key is gone; the id-based key now resolves.
+    assert registry.async_get_entity_id(CLIMATE, DOMAIN, "Study") is None
+    new_entity_id = registry.async_get_entity_id(CLIMATE, DOMAIN, "unit-abc")
+    assert new_entity_id == old.entity_id  # same entity, re-keyed in place
+
+    migrated = registry.async_get(new_entity_id)
+    assert migrated.unique_id == "unit-abc"
+    assert migrated.name == "Study A/C"  # customization preserved
+    assert migrated.area_id == area.id
+
+
+async def test_rekey_removes_autocreated_id_entity_same_entry(hass):
+    """An already auto-created id-keyed orphan is removed so the customized
+    name-keyed entity can migrate onto unit.id."""
+    registry = er.async_get(hass)
+    entry = _entry(hass)
+
+    old = registry.async_get_or_create(
+        CLIMATE, DOMAIN, "Study", config_entry=entry, suggested_object_id="study"
+    )
+    registry.async_update_entity(old.entity_id, name="Study A/C")
+    # 0.0.19 auto-created a fresh id-keyed entity (no customization). Its
+    # suggested object id collides with "study", so HA assigns "study_2".
+    auto = registry.async_get_or_create(
+        CLIMATE, DOMAIN, "unit-abc", config_entry=entry, suggested_object_id="study"
+    )
+    assert auto.entity_id != old.entity_id
+
+    _async_migrate_unique_ids(hass, entry, [_unit("Study", "unit-abc")])
+
+    # The auto-created orphan is removed.
+    assert registry.async_get(auto.entity_id) is None
+    # The ORIGINAL customized entity now owns unit.id and keeps its name.
+    assert registry.async_get_entity_id(CLIMATE, DOMAIN, "unit-abc") == old.entity_id
+    assert registry.async_get_entity_id(CLIMATE, DOMAIN, "Study") is None
+    assert registry.async_get(old.entity_id).name == "Study A/C"
+
+
+async def test_duplicate_unit_names_skipped(hass, caplog):
+    """Two units sharing a name make the single name-keyed entry ambiguous, so
+    no re-key happens for that name."""
+    registry = er.async_get(hass)
+    entry = _entry(hass)
+
+    old = registry.async_get_or_create(
+        CLIMATE, DOMAIN, "AC", config_entry=entry, suggested_object_id="ac"
+    )
+
+    with caplog.at_level(logging.WARNING, logger="custom_components.cool_open_integration"):
+        _async_migrate_unique_ids(
+            hass, entry, [_unit("AC", "id-1"), _unit("AC", "id-2")]
+        )
+
+    # Untouched: still name-keyed, and no id-based entries were created.
+    assert registry.async_get_entity_id(CLIMATE, DOMAIN, "AC") == old.entity_id
+    assert registry.async_get_entity_id(CLIMATE, DOMAIN, "id-1") is None
+    assert registry.async_get_entity_id(CLIMATE, DOMAIN, "id-2") is None
+    # The ambiguous name is reported so the user can disambiguate the units.
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert any("AC" in r.getMessage() for r in warnings)
+
+
+async def test_foreign_owned_old_entity_not_touched(hass):
+    """A name-keyed entity owned by another config entry is left alone."""
+    registry = er.async_get(hass)
+    entry = _entry(hass)
+    other = _entry(hass)
+
+    foreign = registry.async_get_or_create(
+        CLIMATE, DOMAIN, "Study", config_entry=other, suggested_object_id="study"
+    )
+
+    _async_migrate_unique_ids(hass, entry, [_unit("Study", "unit-abc")])
+
+    # Foreign entity unchanged: still name-keyed, still owned by `other`.
+    assert registry.async_get_entity_id(CLIMATE, DOMAIN, "Study") == foreign.entity_id
+    assert registry.async_get(foreign.entity_id).config_entry_id == other.entry_id
+    # No id-based entry was created for our entry.
+    assert registry.async_get_entity_id(CLIMATE, DOMAIN, "unit-abc") is None
+
+
+async def test_foreign_owned_target_id_skips_migration(hass, caplog):
+    """When the target unit.id is already claimed by another config entry, the
+    migration must skip: don't touch our old entity, don't remove the foreign one."""
+    registry = er.async_get(hass)
+    entry = _entry(hass)
+    other = _entry(hass)
+
+    old = registry.async_get_or_create(
+        CLIMATE, DOMAIN, "Study", config_entry=entry, suggested_object_id="study"
+    )
+    registry.async_update_entity(old.entity_id, name="Study A/C")
+    foreign_new = registry.async_get_or_create(
+        CLIMATE, DOMAIN, "unit-abc", config_entry=other, suggested_object_id="other"
+    )
+
+    with caplog.at_level(logging.WARNING, logger="custom_components.cool_open_integration"):
+        _async_migrate_unique_ids(hass, entry, [_unit("Study", "unit-abc")])
+
+    # Our old entity is left as-is (still name-keyed, name preserved).
+    assert registry.async_get_entity_id(CLIMATE, DOMAIN, "Study") == old.entity_id
+    assert registry.async_get(old.entity_id).name == "Study A/C"
+    # The foreign id-keyed entity is NOT removed and stays with `other`.
+    assert registry.async_get_entity_id(CLIMATE, DOMAIN, "unit-abc") == foreign_new.entity_id
+    assert registry.async_get(foreign_new.entity_id).config_entry_id == other.entry_id
+    # The collision is reported (target id owned by another config entry).
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert any("unit-abc" in r.getMessage() for r in warnings)
+
+
+async def test_fresh_install_creates_nothing(hass):
+    """No pre-existing entities: the migration creates nothing."""
+    registry = er.async_get(hass)
+    entry = _entry(hass)
+
+    _async_migrate_unique_ids(hass, entry, [_unit("Study", "unit-abc")])
+
+    assert registry.async_get_entity_id(CLIMATE, DOMAIN, "Study") is None
+    assert registry.async_get_entity_id(CLIMATE, DOMAIN, "unit-abc") is None
+    assert len(registry.entities) == 0
+
+
+async def test_already_migrated_id_entity_untouched(hass):
+    """When only the id-keyed entity exists (no name-keyed), leave it alone."""
+    registry = er.async_get(hass)
+    entry = _entry(hass)
+
+    existing = registry.async_get_or_create(
+        CLIMATE, DOMAIN, "unit-abc", config_entry=entry, suggested_object_id="study"
+    )
+    registry.async_update_entity(existing.entity_id, name="Study A/C")
+
+    _async_migrate_unique_ids(hass, entry, [_unit("Study", "unit-abc")])
+
+    assert registry.async_get_entity_id(CLIMATE, DOMAIN, "Study") is None
+    assert registry.async_get_entity_id(CLIMATE, DOMAIN, "unit-abc") == existing.entity_id
+    assert registry.async_get(existing.entity_id).name == "Study A/C"
+    assert len(registry.entities) == 1
+
+
+async def test_name_equals_id_skipped(hass):
+    """unit.name == unit.id: nothing to migrate; the entity is untouched."""
+    registry = er.async_get(hass)
+    entry = _entry(hass)
+
+    ent = registry.async_get_or_create(
+        CLIMATE, DOMAIN, "same-id", config_entry=entry, suggested_object_id="x"
+    )
+    registry.async_update_entity(ent.entity_id, name="Custom")
+
+    _async_migrate_unique_ids(hass, entry, [_unit("same-id", "same-id")])
+
+    assert registry.async_get_entity_id(CLIMATE, DOMAIN, "same-id") == ent.entity_id
+    assert registry.async_get(ent.entity_id).name == "Custom"
+    assert len(registry.entities) == 1
+
+
+async def test_falsy_unit_name_skipped(hass):
+    """A falsy unit.name yields no name-based lookup; an id-keyed entity that
+    happens to exist for that unit is untouched (no re-key attempted)."""
+    registry = er.async_get(hass)
+    entry = _entry(hass)
+
+    ent = registry.async_get_or_create(
+        CLIMATE, DOMAIN, "unit-x", config_entry=entry, suggested_object_id="x"
+    )
+    registry.async_update_entity(ent.entity_id, name="Kept")
+
+    _async_migrate_unique_ids(hass, entry, [_unit("", "unit-x")])
+
+    assert registry.async_get_entity_id(CLIMATE, DOMAIN, "unit-x") == ent.entity_id
+    assert registry.async_get(ent.entity_id).name == "Kept"
+    assert len(registry.entities) == 1


### PR DESCRIPTION
## Problem
PR #13 changed the climate `unique_id` from `unit.name` to `unit.id` **without an entity-registry migration**. It first shipped in **0.0.19**, so on upgrade HA treated every climate entity as new: the old name-keyed registry entries (holding users' custom names/areas) were orphaned and fresh id-keyed entities were created. Result: a unit the user had renamed "Study A/C" reverted to "Study", areas were lost, etc.

## Fix
Keep the correct stable `unit.id` unique_id (names are mutable and can collide — that was PR #13's valid intent) and add the missing migration in `async_setup_entry` (after units are fetched, before platform forward). Per unit:
1. Find the old registry entry keyed by `unit.name`; skip if absent (fresh install / already migrated).
2. **Scope to this config entry** (`async_get_entity_id` matches globally across accounts) — never touch another account's entities.
3. **Skip duplicate unit names** — the single name-keyed entry is ambiguous, so re-keying could attach the wrong unit's customizations (warns).
4. If an id-keyed entry was already auto-created (0.0.19/0.0.20), remove that orphan first (only if it belongs to this entry; otherwise warn + skip), then
5. `async_update_entity(old, new_unique_id=unit.id)` — re-keys the customized entry in place, preserving entity_id, name, and area.

Recovers **both** already-upgraded users and fresh upgraders in one release, with no `unique_id` flip-flop.

## Tests
`tests/test_init_migration.py` — 9 cases against a real entity registry covering every branch: plain re-key (customizations preserved), already-upgraded orphan-removal + re-key, duplicate-name skip, foreign-config-entry old/new not touched, fresh install / already-migrated / name==id / empty-name no-ops. Full suite: **67 passed**.

Ships as 0.0.21.